### PR TITLE
Add FastAPI backend and Vite front/backoffice with Docker setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,10 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Node / frontend assets
+node_modules/
+dist/
+frontend/node_modules/
+backoffice/node_modules/
+!backoffice/src/lib/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+# syntax=docker/dockerfile:1.4
+
+#############################
+# Frontend (React + Vite)
+#############################
+FROM node:20-bullseye-slim AS frontend
+WORKDIR /app
+COPY frontend/package*.json ./frontend/
+RUN --mount=type=cache,target=/root/.npm cd frontend && npm install
+COPY frontend ./frontend
+WORKDIR /app/frontend
+CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0", "--port", "2048"]
+
+#############################
+# Backoffice (Vite + shadcn)
+#############################
+FROM node:20-bullseye-slim AS backoffice
+WORKDIR /app
+COPY backoffice/package*.json ./backoffice/
+RUN --mount=type=cache,target=/root/.npm cd backoffice && npm install
+COPY backoffice ./backoffice
+WORKDIR /app/backoffice
+CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0", "--port", "2050"]
+
+#############################
+# Backend (FastAPI)
+#############################
+FROM python:3.11-slim AS backend
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+WORKDIR /app
+COPY backend/requirements.txt ./backend/requirements.txt
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir -r backend/requirements.txt
+COPY backend /app/backend
+COPY json /app/json
+ENV COURSES_DATA_DIR=/app/json
+ENV PYTHONPATH=/app
+CMD ["uvicorn", "backend.app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # English Teacher
 
 ## Product
-English Teacher is a content production toolkit for building business-focused English courses. Educators can outline an eight-session syllabus and automatically produce consistent lesson assets for every session. The repo includes reference topics such as **Customer and distribution** and **Marketing and advertising**, each designed with eight sessions and eight slides per session so learners gain repeated practice across vocabulary, analysis, and presentation skills.
+English Teacher is a content production toolkit for building business-focused English courses. Educators can outline an eight-session syllabus and automatically produce consistent lesson assets for every session. The repo includes reference topics such as **Customer and distribution** and **Marketing and advertising**, each designed with eight sessions and eight slides per session so learners gain repeated practice across vocabulary, analysis, and presentation skills. The toolkit now ships with dedicated frontend, backend, and backoffice apps so teams can browse, QA, and govern these multi-session catalogues from the browser as well as the command line.
 
 ## UX
-Course builders work through a predictable set of deliverables. Markdown drafts live in `_original/`, JSON handoffs populate `json/`, and slide decks render in `slides/`. Helper scripts (`main.py`, `slides.py`, and `doc.py`) keep the workflow command-line friendly—run them from the project root to preview console output or regenerate artifacts once new content is ready. Prompts inside the repository guide how to brief the DOCAI assistant when fresh course sessions or slide scripts are needed.
+Course builders work through a predictable set of deliverables. Markdown drafts live in `_original/`, JSON handoffs populate `json/`, and slide decks render in `slides/`. Helper scripts (`main.py`, `slides.py`, and `doc.py`) keep the workflow command-line friendly—run them from the project root to preview console output or regenerate artifacts once new content is ready. Prompts inside the repository guide how to brief the DOCAI assistant when fresh course sessions or slide scripts are needed. The new React interfaces mirror this flow: the `frontend/` catalogue highlights eight-session outlines for stakeholders, while the `backoffice/` dashboard gives editors shadcn-styled controls for searching, validating, and linking course assets.
 
 ## Tech
 The project is written in Python and leans on small utilities in `dev/`:
@@ -13,6 +13,12 @@ The project is written in Python and leans on small utilities in `dev/`:
 - `courses_google_slides.py` connects to the Google Slides API to build presentations programmatically.
 Supporting scripts share configuration for input/output folders so assets land in predictable directories alongside the source files.
 
+The repo is now organised as a three-service stack:
+- `backend/` hosts a FastAPI application that surfaces the course JSON catalogue, search helpers, and detailed slide data on port **2049**.
+- `frontend/` contains a React + Vite client (port **2048**) that visualises every eight-session syllabus.
+- `backoffice/` is a Vite project styled with the shadcn design system and Tailwind CSS; it provides admin-grade controls on port **2050**.
+Shared Docker tooling (`Dockerfile`, `docker-compose.yml`, and `bash.sh`) automates local builds so the FastAPI API, Vite dev servers, and course assets stay in sync.
+
 ## Flow
 1. Outline a course session in Markdown, following the eight-section template (Introduction, four numbered topics, Conclusion, Next steps, and Extra slide).
 2. Use the DOCAI assistant to expand the outline into a fully populated CSV/JSON structure with titles, subtitles, intros, key ideas, and examples for every slide.
@@ -20,5 +26,13 @@ Supporting scripts share configuration for input/output folders so assets land i
 4. Generate presentation decks through `python3 slides.py`, or trigger the Google Slides workflow when a connected account is available.
 5. Review the produced materials, update objectives or transitions as needed, and iterate until each session meets the target learning outcomes.
 
+Run the containerised stack from the project root whenever you want to explore the catalogue in the browser (React frontend, FastAPI backend, and shadcn backoffice will all rebuild):
+
+```bash
+./bash.sh
+```
+
+Once the services are up you can visit http://localhost:2048 for the learner-facing catalogue, http://localhost:2049 for the API, and http://localhost:2050 for the backoffice controls.
+
 ## Marketing
-Position English Teacher as an accelerator for bilingual business programs. Highlight how automated slide scripts, consistent lesson templates, and branded prompts reduce prep time while keeping instruction aligned with professional use cases (e.g., Nike or Apple storytelling). Emphasize smooth slide transitions, clearly stated objectives, and concrete case studies so stakeholders see both pedagogical rigor and marketing polish.
+Position English Teacher as an accelerator for bilingual business programs. Highlight how automated slide scripts, consistent lesson templates, and branded prompts reduce prep time while keeping instruction aligned with professional use cases (e.g., Nike or Apple storytelling). Emphasize smooth slide transitions, clearly stated objectives, and concrete case studies so stakeholders see both pedagogical rigor and marketing polish. The new multi-app stack makes it easier to demo catalogue breadth to prospects, hand reviewers the API, and showcase shadcn-polished admin workflows alongside the eight-session learning journeys.

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,4 @@
+"""Expose the FastAPI application for ASGI servers."""
+from .main import app
+
+__all__ = ["app"]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,57 @@
+"""FastAPI application exposing course data endpoints."""
+from __future__ import annotations
+
+import os
+from typing import List
+
+from fastapi import Depends, FastAPI, Query
+from fastapi.middleware.cors import CORSMiddleware
+
+from .models import CourseDetail, CourseSummary
+from .storage import CourseStore, discover_data_directory
+
+
+def get_store() -> CourseStore:
+    data_dir = os.environ.get("COURSES_DATA_DIR")
+    directory = discover_data_directory(data_dir)
+    return CourseStore(directory)
+
+
+app = FastAPI(title="Courses API", version="1.0.0")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+@app.get("/", summary="Service information")
+def read_root() -> dict[str, str]:
+    return {
+        "message": "English Teacher course API",
+        "documentation": "/docs",
+    }
+
+
+@app.get("/health", summary="Health check")
+def healthcheck() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.get("/courses", response_model=List[CourseSummary], summary="List courses")
+def list_courses(store: CourseStore = Depends(get_store), search: str | None = Query(default=None)) -> List[CourseSummary]:
+    if search:
+        return store.search(search)
+    return store.list_courses()
+
+
+@app.get(
+    "/courses/{identifier}",
+    response_model=CourseDetail,
+    summary="Retrieve a course by slug or identifier",
+)
+def get_course(identifier: str, store: CourseStore = Depends(get_store)) -> CourseDetail:
+    return store.get_course(identifier)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,0 +1,159 @@
+"""Pydantic models describing the course data returned by the API."""
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Iterable, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class CourseMetadata(BaseModel):
+    """High level metadata extracted from the course JSON files."""
+
+    id: str
+    slug: str
+    title: str
+    name: Optional[str] = None
+    tagline: Optional[str] = None
+    description: Optional[str] = None
+    status: Optional[str] = None
+    category: Optional[str] = None
+    cta: Optional[str] = None
+    year: Optional[str] = None
+    updated: Optional[datetime] = None
+    topics: List[str] = Field(default_factory=list)
+    source: str
+
+
+class CourseSession(BaseModel):
+    """A single item (or slide) inside a course."""
+
+    id: str
+    title: Optional[str] = None
+    name: Optional[str] = None
+    slug: Optional[str] = None
+    tagline: Optional[str] = None
+    description: Optional[str] = None
+    keyIdeas: List[str] = Field(default_factory=list)
+    status: Optional[str] = None
+    category: Optional[str] = None
+    db: Optional[str] = None
+    collection: Optional[str] = None
+    data: Optional[str] = None
+    callToAction: Optional[str] = None
+    year: Optional[str] = None
+    image: Optional[str] = None
+    rank: Optional[int] = None
+
+
+class CourseSummary(BaseModel):
+    """Summary information surfaced in the course list view."""
+
+    id: str
+    slug: str
+    title: str
+    description: Optional[str] = None
+    tagline: Optional[str] = None
+    status: Optional[str] = None
+    topics: List[str] = Field(default_factory=list)
+    updated: Optional[datetime] = None
+    source: str
+
+
+class CourseDetail(CourseSummary):
+    """Full course payload returned for detail views."""
+
+    metadata: CourseMetadata
+    sessions: List[CourseSession] = Field(default_factory=list)
+
+
+def build_metadata(raw: dict[str, Any], source: Path, fallback_slug: str) -> CourseMetadata:
+    """Transform raw ``listData`` dictionaries into :class:`CourseMetadata`."""
+
+    topics = raw.get("topics") or []
+    date_str = raw.get("date")
+    updated = None
+    if isinstance(date_str, str):
+        try:
+            updated = datetime.fromisoformat(date_str.strip())
+        except ValueError:
+            updated = None
+
+    slug = raw.get("slug") or fallback_slug
+    course_id = raw.get("id") or raw.get("slug") or raw.get("name") or fallback_slug
+
+    metadata = CourseMetadata(
+        id=str(course_id),
+        slug=str(slug),
+        title=raw.get("title") or raw.get("name") or fallback_slug,
+        name=raw.get("name"),
+        tagline=raw.get("tagline"),
+        description=raw.get("description"),
+        status=raw.get("status"),
+        category=raw.get("cat"),
+        cta=raw.get("cta"),
+        year=raw.get("year"),
+        updated=updated,
+        topics=[str(topic) for topic in topics],
+        source=str(source),
+    )
+    return metadata
+
+
+def build_sessions(raw_sessions: Iterable[dict[str, Any]]) -> List[CourseSession]:
+    """Convert raw session dictionaries to :class:`CourseSession` objects."""
+
+    sessions: List[CourseSession] = []
+    for raw in raw_sessions:
+        if not isinstance(raw, dict):
+            continue
+        session_id = raw.get("id") or raw.get("slug")
+        if not session_id:
+            continue
+        session = CourseSession(
+            id=str(session_id),
+            title=raw.get("title") or raw.get("name"),
+            name=raw.get("name"),
+            slug=raw.get("slug"),
+            tagline=raw.get("tagline"),
+            description=raw.get("description"),
+            keyIdeas=[str(item) for item in raw.get("key-ideas", []) if isinstance(item, str)],
+            status=raw.get("status"),
+            category=raw.get("cat"),
+            db=raw.get("db"),
+            collection=raw.get("collection"),
+            data=raw.get("data"),
+            callToAction=raw.get("cta"),
+            year=raw.get("year"),
+            image=raw.get("image"),
+            rank=raw.get("rank"),
+        )
+        sessions.append(session)
+    return sessions
+
+
+def build_summary(metadata: CourseMetadata) -> CourseSummary:
+    """Create a :class:`CourseSummary` from :class:`CourseMetadata`."""
+
+    return CourseSummary(
+        id=metadata.id,
+        slug=metadata.slug,
+        title=metadata.title,
+        description=metadata.description,
+        tagline=metadata.tagline,
+        status=metadata.status,
+        topics=list(metadata.topics),
+        updated=metadata.updated,
+        source=metadata.source,
+    )
+
+
+def build_detail(metadata: CourseMetadata, sessions: Iterable[CourseSession]) -> CourseDetail:
+    """Create a :class:`CourseDetail` from metadata and sessions."""
+
+    return CourseDetail(
+        **build_summary(metadata).model_dump(),
+        metadata=metadata,
+        sessions=list(sessions),
+    )

--- a/backend/app/storage.py
+++ b/backend/app/storage.py
@@ -1,0 +1,128 @@
+"""Utilities for loading course JSON files."""
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import List, Optional
+
+from fastapi import HTTPException, status
+
+from .models import (
+    CourseDetail,
+    CourseMetadata,
+    CourseSession,
+    CourseSummary,
+    build_detail,
+    build_metadata,
+    build_sessions,
+    build_summary,
+)
+
+
+class CourseStore:
+    """Load and cache course definitions stored as JSON files."""
+
+    def __init__(self, data_dir: Path) -> None:
+        self.data_dir = data_dir
+        if not self.data_dir.exists():
+            raise FileNotFoundError(f"Course data directory does not exist: {self.data_dir}")
+
+    @property
+    def json_files(self) -> List[Path]:
+        """Return all JSON files sorted alphabetically."""
+
+        return sorted(self.data_dir.glob("*.json"))
+
+    def _read_json(self, path: Path) -> dict:
+        try:
+            with path.open("r", encoding="utf-8") as handle:
+                return json.load(handle)
+        except FileNotFoundError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Course file not found: {path.name}",
+            ) from exc
+        except json.JSONDecodeError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=f"Invalid JSON in {path.name}: {exc.msg}",
+            ) from exc
+
+    @lru_cache(maxsize=256)
+    def _metadata_for(self, path: Path) -> CourseMetadata:
+        raw = self._read_json(path)
+        list_data = raw.get("listData") or {}
+        if not list_data:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=f"Missing listData in {path.name}",
+            )
+        return build_metadata(list_data, source=path, fallback_slug=path.stem)
+
+    @lru_cache(maxsize=256)
+    def _sessions_for(self, path: Path) -> List[CourseSession]:
+        raw = self._read_json(path)
+        list_items = raw.get("listItems") or []
+        return build_sessions(list_items)
+
+    def list_courses(self) -> List[CourseSummary]:
+        summaries: List[CourseSummary] = []
+        for file_path in self.json_files:
+            try:
+                metadata = self._metadata_for(file_path)
+            except HTTPException:
+                continue
+            summaries.append(build_summary(metadata))
+        return summaries
+
+    def get_course(self, identifier: str) -> CourseDetail:
+        path = self._resolve_identifier(identifier)
+        metadata = self._metadata_for(path)
+        sessions = self._sessions_for(path)
+        return build_detail(metadata, sessions)
+
+    def _resolve_identifier(self, identifier: str) -> Path:
+        candidate = self.data_dir / f"{identifier}.json"
+        if candidate.exists():
+            return candidate
+
+        for file_path in self.json_files:
+            metadata = self._metadata_for(file_path)
+            if identifier in {metadata.id, metadata.slug}:
+                return file_path
+
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Course '{identifier}' not found",
+        )
+
+    def search(self, query: str) -> List[CourseSummary]:
+        query_lower = query.lower()
+        results: List[CourseSummary] = []
+        for summary in self.list_courses():
+            haystack = " ".join(
+                [
+                    summary.title or "",
+                    summary.description or "",
+                    " ".join(summary.topics),
+                ]
+            ).lower()
+            if query_lower in haystack:
+                results.append(summary)
+        return results
+
+
+def discover_data_directory(candidate: Optional[str] = None) -> Path:
+    """Find the directory containing the course JSON files."""
+
+    if candidate:
+        directory = Path(candidate).expanduser().resolve()
+    else:
+        directory = Path(__file__).resolve().parents[2] / "json"
+    if not directory.exists():
+        raise FileNotFoundError(
+            f"Unable to locate course data directory at {directory}. "
+            "Set the COURSES_DATA_DIR environment variable to override."
+        )
+    return directory

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.109.2
+uvicorn[standard]==0.27.1
+python-multipart==0.0.9

--- a/backoffice/index.html
+++ b/backoffice/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>English Teacher Backoffice</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/backoffice/package.json
+++ b/backoffice/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "courses-backoffice",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite --host 0.0.0.0 --port 2050",
+    "build": "vite build",
+    "preview": "vite preview --host 0.0.0.0 --port 4174"
+  },
+  "dependencies": {
+    "@radix-ui/react-slot": "^1.0.2",
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^1.2.1",
+    "lucide-react": "^0.344.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "tailwind-merge": "^2.2.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.45",
+    "@types/react-dom": "^18.2.17",
+    "@vitejs/plugin-react": "^4.2.0",
+    "autoprefixer": "^10.4.16",
+    "postcss": "^8.4.32",
+    "tailwindcss": "^3.3.6",
+    "tailwindcss-animate": "^1.0.7",
+    "typescript": "^5.2.2",
+    "vite": "^5.1.0"
+  }
+}

--- a/backoffice/postcss.config.cjs
+++ b/backoffice/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/backoffice/src/App.tsx
+++ b/backoffice/src/App.tsx
@@ -1,0 +1,397 @@
+import { type FormEvent, useCallback, useEffect, useMemo, useState } from "react";
+import { BookOpen, CalendarClock, ExternalLink, ListChecks, RefreshCw, Search } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+
+const DEFAULT_API = "http://localhost:2049";
+
+interface CourseSummary {
+  id: string;
+  slug: string;
+  title: string;
+  description?: string | null;
+  tagline?: string | null;
+  status?: string | null;
+  topics: string[];
+  updated?: string | null;
+  source: string;
+}
+
+interface CourseMetadata {
+  id: string;
+  slug: string;
+  title: string;
+  name?: string | null;
+  tagline?: string | null;
+  description?: string | null;
+  status?: string | null;
+  category?: string | null;
+  cta?: string | null;
+  year?: string | null;
+  topics: string[];
+  updated?: string | null;
+  source: string;
+}
+
+interface CourseSession {
+  id: string;
+  title?: string | null;
+  name?: string | null;
+  tagline?: string | null;
+  description?: string | null;
+  keyIdeas: string[];
+  status?: string | null;
+  category?: string | null;
+  callToAction?: string | null;
+  year?: string | null;
+  rank?: number | null;
+  image?: string | null;
+}
+
+interface CourseDetail extends CourseSummary {
+  metadata: CourseMetadata;
+  sessions: CourseSession[];
+}
+
+function formatDate(value?: string | null) {
+  if (!value) return null;
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+  return parsed.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function useApiBase() {
+  return useMemo(() => {
+    const base = import.meta.env.VITE_API_URL || DEFAULT_API;
+    return String(base).replace(/\/$/, "");
+  }, []);
+}
+
+export default function App() {
+  const apiBase = useApiBase();
+  const [courses, setCourses] = useState<CourseSummary[]>([]);
+  const [selectedCourse, setSelectedCourse] = useState<CourseDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [searching, setSearching] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [searchTerm, setSearchTerm] = useState("");
+
+  const loadCourses = useCallback(
+    async (query?: string) => {
+      setError(null);
+      setLoading(!query);
+      setSearching(Boolean(query));
+      try {
+        const url = new URL(`${apiBase}/courses`);
+        if (query) {
+          url.searchParams.set("search", query);
+        }
+        const response = await fetch(url);
+        if (!response.ok) {
+          throw new Error(`Unable to fetch courses (status ${response.status})`);
+        }
+        const payload = (await response.json()) as CourseSummary[];
+        setCourses(payload);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+        setCourses([]);
+      } finally {
+        setLoading(false);
+        setSearching(false);
+      }
+    },
+    [apiBase]
+  );
+
+  const loadCourseDetail = useCallback(
+    async (identifier: string) => {
+      setError(null);
+      try {
+        const response = await fetch(`${apiBase}/courses/${identifier}`);
+        if (!response.ok) {
+          throw new Error(`Course ${identifier} could not be loaded`);
+        }
+        const payload = (await response.json()) as CourseDetail;
+        setSelectedCourse(payload);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+        setSelectedCourse(null);
+      }
+    },
+    [apiBase]
+  );
+
+  useEffect(() => {
+    loadCourses().catch((err) => {
+      console.error(err);
+    });
+  }, [loadCourses]);
+
+  const handleSearch = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      await loadCourses(searchTerm.trim() || undefined);
+    },
+    [loadCourses, searchTerm]
+  );
+
+  const handleRefresh = useCallback(async () => {
+    setSearchTerm("");
+    await loadCourses();
+  }, [loadCourses]);
+
+  const handleSelect = useCallback(
+    async (course: CourseSummary) => {
+      await loadCourseDetail(course.slug || course.id);
+    },
+    [loadCourseDetail]
+  );
+
+  return (
+    <div className="min-h-screen bg-muted/30">
+      <header className="border-b bg-white">
+        <div className="container mx-auto flex flex-col gap-4 px-6 py-6 md:flex-row md:items-center md:justify-between">
+          <div className="flex items-center gap-4">
+            <span className="flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+              <BookOpen className="h-6 w-6" aria-hidden="true" />
+            </span>
+            <div>
+              <h1 className="text-2xl font-semibold tracking-tight">English Teacher Backoffice</h1>
+              <p className="text-sm text-muted-foreground">
+                Monitor JSON-driven course assets and keep eight-session roadmaps aligned.
+              </p>
+            </div>
+          </div>
+          <Button variant="outline" onClick={handleRefresh} className="w-full md:w-auto">
+            <RefreshCw className="mr-2 h-4 w-4" aria-hidden="true" /> Reload catalogue
+          </Button>
+        </div>
+      </header>
+
+      <main className="container mx-auto grid gap-6 px-6 py-10 lg:grid-cols-[360px_1fr]">
+        <Card>
+          <CardHeader>
+            <CardTitle>Course library</CardTitle>
+            <CardDescription>Loaded from the repository&apos;s json/ directory.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <form onSubmit={handleSearch} className="space-y-3">
+              <label className="flex flex-col gap-2 text-sm font-medium text-muted-foreground">
+                Search catalogue
+                <div className="relative">
+                  <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                  <Input
+                    placeholder="Filter by title, description, or topics"
+                    className="pl-9"
+                    value={searchTerm}
+                    onChange={(event) => setSearchTerm(event.target.value)}
+                  />
+                </div>
+              </label>
+              <div className="flex gap-2">
+                <Button type="submit" className="flex-1" disabled={searching}>
+                  {searching ? "Searching…" : "Apply filters"}
+                </Button>
+                <Button type="button" variant="ghost" onClick={handleRefresh}>
+                  Reset
+                </Button>
+              </div>
+            </form>
+            <div className="space-y-2">
+              {loading ? (
+                <p className="text-sm text-muted-foreground">Loading courses…</p>
+              ) : error ? (
+                <p className="text-sm text-destructive">{error}</p>
+              ) : courses.length === 0 ? (
+                <p className="text-sm text-muted-foreground">No courses match the current filters.</p>
+              ) : (
+                <ul className="space-y-2">
+                  {courses.map((course) => (
+                    <li key={course.id}>
+                      <button
+                        type="button"
+                        onClick={() => handleSelect(course)}
+                        className="w-full rounded-xl border border-border bg-white px-4 py-3 text-left shadow-sm transition hover:border-primary/40 hover:bg-primary/5"
+                      >
+                        <div className="flex items-start justify-between gap-3">
+                          <div>
+                            <p className="font-semibold text-foreground">{course.title}</p>
+                            {course.tagline && (
+                              <p className="text-xs text-muted-foreground">{course.tagline}</p>
+                            )}
+                          </div>
+                          {course.status && (
+                            <span className="rounded-full bg-secondary px-3 py-0.5 text-xs font-medium text-secondary-foreground">
+                              {course.status}
+                            </span>
+                          )}
+                        </div>
+                        {course.topics?.length ? (
+                          <p className="mt-2 line-clamp-2 text-xs text-muted-foreground">
+                            Topics: {course.topics.join(", ")}
+                          </p>
+                        ) : null}
+                        {formatDate(course.updated) && (
+                          <p className="mt-1 flex items-center gap-1 text-[11px] uppercase tracking-wide text-muted-foreground">
+                            <CalendarClock className="h-3.5 w-3.5" /> Updated {formatDate(course.updated)}
+                          </p>
+                        )}
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+
+        <DetailPanel course={selectedCourse} error={error} />
+      </main>
+    </div>
+  );
+}
+
+function DetailPanel({ course, error }: { course: CourseDetail | null; error: string | null }) {
+  if (error && !course) {
+    return (
+      <Card className="border-destructive/40 bg-destructive/5">
+        <CardHeader>
+          <CardTitle className="text-destructive">Unable to load course</CardTitle>
+          <CardDescription className="text-destructive">{error}</CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  if (!course) {
+    return (
+      <Card className="flex h-full flex-col items-center justify-center border-dashed text-center text-muted-foreground">
+        <ListChecks className="mb-4 h-12 w-12" aria-hidden="true" />
+        <CardTitle className="text-lg">Select a course to inspect its sessions</CardTitle>
+        <CardDescription className="px-10">
+          Use the library panel to review JSON metadata, session objectives, and slide-ready bullet points
+          for each eight-session programme.
+        </CardDescription>
+      </Card>
+    );
+  }
+
+  const updatedLabel = formatDate(course.metadata.updated);
+
+  return (
+    <Card className="h-full">
+      <CardHeader className="space-y-3">
+        <div className="space-y-1">
+          <CardTitle>{course.title}</CardTitle>
+          {course.tagline && <CardDescription>{course.tagline}</CardDescription>}
+        </div>
+        <div className="grid gap-3 text-sm text-muted-foreground">
+          {course.metadata.description && <p>{course.metadata.description}</p>}
+          <div className="flex flex-wrap gap-2">
+            {course.metadata.topics.map((topic) => (
+              <span
+                key={topic}
+                className="rounded-full bg-primary/10 px-3 py-1 text-xs font-medium text-primary"
+              >
+                {topic}
+              </span>
+            ))}
+          </div>
+          <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-xs uppercase tracking-wide text-muted-foreground/90">
+            {course.metadata.status && (
+              <>
+                <dt>Status</dt>
+                <dd className="font-medium text-foreground">{course.metadata.status}</dd>
+              </>
+            )}
+            {course.metadata.category && (
+              <>
+                <dt>Category</dt>
+                <dd className="font-medium text-foreground">{course.metadata.category}</dd>
+              </>
+            )}
+            {course.metadata.year && (
+              <>
+                <dt>Year</dt>
+                <dd className="font-medium text-foreground">{course.metadata.year}</dd>
+              </>
+            )}
+            {updatedLabel && (
+              <>
+                <dt>Updated</dt>
+                <dd className="font-medium text-foreground">{updatedLabel}</dd>
+              </>
+            )}
+            <dt>Source</dt>
+            <dd className="break-all font-medium text-foreground">{course.source}</dd>
+            {course.metadata.cta && (
+              <>
+                <dt>CTA</dt>
+                <dd>
+                  <a className="inline-flex items-center gap-1 text-primary underline" href={course.metadata.cta} target="_blank" rel="noreferrer">
+                    Visit link <ExternalLink className="h-3 w-3" />
+                  </a>
+                </dd>
+              </>
+            )}
+          </dl>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <section>
+          <div className="flex items-center justify-between">
+            <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Sessions</h3>
+            <span className="text-xs text-muted-foreground">{course.sessions.length} items</span>
+          </div>
+          <ol className="mt-4 space-y-4">
+            {course.sessions.map((session, index) => (
+              <li key={session.id} className="rounded-xl border border-border bg-card/40 p-4 shadow-sm">
+                <div className="flex items-start justify-between gap-4">
+                  <div>
+                    <p className="text-sm font-semibold text-foreground">
+                      {index + 1}. {session.title || session.name}
+                    </p>
+                    {session.tagline && <p className="text-xs text-muted-foreground">{session.tagline}</p>}
+                  </div>
+                  {session.rank && (
+                    <span className="rounded-full bg-primary/10 px-3 py-0.5 text-xs font-semibold text-primary">
+                      Rank {session.rank}
+                    </span>
+                  )}
+                </div>
+                {session.description && (
+                  <p className="mt-2 text-sm text-muted-foreground">{session.description}</p>
+                )}
+                {session.keyIdeas?.length ? (
+                  <ul className="mt-3 list-disc space-y-1 pl-5 text-sm text-muted-foreground">
+                    {session.keyIdeas.map((idea, ideaIndex) => (
+                      <li key={`${session.id}-${ideaIndex}`}>{idea}</li>
+                    ))}
+                  </ul>
+                ) : null}
+                {session.callToAction && (
+                  <a
+                    href={session.callToAction}
+                    className="mt-3 inline-flex items-center gap-1 text-xs font-semibold text-primary hover:underline"
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    Explore resources <ExternalLink className="h-3 w-3" />
+                  </a>
+                )}
+              </li>
+            ))}
+          </ol>
+        </section>
+      </CardContent>
+    </Card>
+  );
+}

--- a/backoffice/src/components/ui/button.tsx
+++ b/backoffice/src/components/ui/button.tsx
@@ -1,0 +1,49 @@
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+        outline: "border border-borderStrong text-foreground hover:bg-accent hover:text-accent-foreground",
+        secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-10 px-4 py-2",
+        sm: "h-9 rounded-md px-3",
+        lg: "h-11 rounded-md px-8",
+        icon: "h-10 w-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button";
+    return (
+      <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />
+    );
+  }
+);
+Button.displayName = "Button";
+
+export { Button, buttonVariants };

--- a/backoffice/src/components/ui/card.tsx
+++ b/backoffice/src/components/ui/card.tsx
@@ -1,0 +1,51 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn("rounded-2xl border border-border bg-card text-card-foreground shadow-sm", className)}
+      {...props}
+    />
+  )
+);
+Card.displayName = "Card";
+
+const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("flex flex-col space-y-1.5 p-6", className)} {...props} />
+  )
+);
+CardHeader.displayName = "CardHeader";
+
+const CardTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLHeadingElement>>(
+  ({ className, ...props }, ref) => (
+    <h3 ref={ref} className={cn("text-2xl font-semibold leading-none tracking-tight", className)} {...props} />
+  )
+);
+CardTitle.displayName = "CardTitle";
+
+const CardDescription = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
+  ({ className, ...props }, ref) => (
+    <p ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />
+  )
+);
+CardDescription.displayName = "CardDescription";
+
+const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+  )
+);
+CardContent.displayName = "CardContent";
+
+const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("flex items-center p-6 pt-0", className)} {...props} />
+  )
+);
+CardFooter.displayName = "CardFooter";
+
+export { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter };

--- a/backoffice/src/components/ui/input.tsx
+++ b/backoffice/src/components/ui/input.tsx
@@ -1,0 +1,20 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Input = React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLInputElement>>(
+  ({ className, type = "text", ...props }, ref) => (
+    <input
+      type={type}
+      className={cn(
+        "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      ref={ref}
+      {...props}
+    />
+  )
+);
+Input.displayName = "Input";
+
+export { Input };

--- a/backoffice/src/index.css
+++ b/backoffice/src/index.css
@@ -1,0 +1,62 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  :root {
+    --background: 0 0% 100%;
+    --foreground: 222.2 84% 4.9%;
+    --card: 0 0% 100%;
+    --card-foreground: 222.2 84% 4.9%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 222.2 84% 4.9%;
+    --primary: 215 58% 52%;
+    --primary-foreground: 210 40% 98%;
+    --secondary: 210 40% 96%;
+    --secondary-foreground: 222.2 47.4% 11.2%;
+    --muted: 210 40% 96.1%;
+    --muted-foreground: 215 16% 46%;
+    --accent: 210 40% 96.1%;
+    --accent-foreground: 222.2 47.4% 11.2%;
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 210 40% 98%;
+    --border: 214.3 31.8% 91.4%;
+    --border-strong: 215 20% 65%;
+    --input: 214.3 31.8% 91.4%;
+    --ring: 215 20.2% 65.1%;
+    --radius: 0.75rem;
+  }
+
+  .dark {
+    --background: 222.2 84% 4.9%;
+    --foreground: 210 40% 98%;
+    --card: 222.2 84% 4.9%;
+    --card-foreground: 210 40% 98%;
+    --popover: 222.2 84% 4.9%;
+    --popover-foreground: 210 40% 98%;
+    --primary: 210 40% 98%;
+    --primary-foreground: 222.2 47.4% 11.2%;
+    --secondary: 217.2 32.6% 17.5%;
+    --secondary-foreground: 210 40% 98%;
+    --muted: 217.2 32.6% 17.5%;
+    --muted-foreground: 215 20.2% 65.1%;
+    --accent: 217.2 32.6% 17.5%;
+    --accent-foreground: 210 40% 98%;
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 210 40% 98%;
+    --border: 217.2 32.6% 17.5%;
+    --border-strong: 215 20% 65%;
+    --input: 217.2 32.6% 17.5%;
+    --ring: 212.7 26.8% 83.9%;
+    --radius: 0.75rem;
+  }
+}
+
+@layer base {
+  * {
+    @apply border-border;
+  }
+  body {
+    @apply bg-background text-foreground;
+  }
+}

--- a/backoffice/src/lib/utils.ts
+++ b/backoffice/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/backoffice/src/main.tsx
+++ b/backoffice/src/main.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+
+import App from "./App";
+import "./index.css";
+
+ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/backoffice/tailwind.config.ts
+++ b/backoffice/tailwind.config.ts
@@ -1,0 +1,76 @@
+import type { Config } from "tailwindcss";
+import defaultTheme from "tailwindcss/defaultTheme";
+import tailwindcssAnimate from "tailwindcss-animate";
+
+const config: Config = {
+  darkMode: ["class"],
+  content: ["./index.html", "./src/**/*.{ts,tsx,js,jsx}"],
+  theme: {
+    container: {
+      center: true,
+      padding: "1.5rem",
+      screens: {
+        "2xl": "1400px",
+      },
+    },
+    extend: {
+      colors: {
+        border: "hsl(var(--border))",
+        input: "hsl(var(--input))",
+        ring: "hsl(var(--ring))",
+        background: "hsl(var(--background))",
+        foreground: "hsl(var(--foreground))",
+        primary: {
+          DEFAULT: "hsl(var(--primary))",
+          foreground: "hsl(var(--primary-foreground))",
+        },
+        secondary: {
+          DEFAULT: "hsl(var(--secondary))",
+          foreground: "hsl(var(--secondary-foreground))",
+        },
+        muted: {
+          DEFAULT: "hsl(var(--muted))",
+          foreground: "hsl(var(--muted-foreground))",
+        },
+        accent: {
+          DEFAULT: "hsl(var(--accent))",
+          foreground: "hsl(var(--accent-foreground))",
+        },
+        destructive: {
+          DEFAULT: "hsl(var(--destructive))",
+          foreground: "hsl(var(--destructive-foreground))",
+        },
+        borderStrong: "hsl(var(--border-strong))",
+        card: {
+          DEFAULT: "hsl(var(--card))",
+          foreground: "hsl(var(--card-foreground))",
+        },
+      },
+      borderRadius: {
+        lg: "var(--radius)",
+        md: "calc(var(--radius) - 2px)",
+        sm: "calc(var(--radius) - 4px)",
+      },
+      fontFamily: {
+        sans: ["Inter", ...defaultTheme.fontFamily.sans],
+      },
+      keyframes: {
+        "accordion-down": {
+          from: { height: "0" },
+          to: { height: "var(--radix-accordion-content-height)" },
+        },
+        "accordion-up": {
+          from: { height: "var(--radix-accordion-content-height)" },
+          to: { height: "0" },
+        },
+      },
+      animation: {
+        "accordion-down": "accordion-down 0.2s ease-out",
+        "accordion-up": "accordion-up 0.2s ease-out",
+      },
+    },
+  },
+  plugins: [tailwindcssAnimate],
+};
+
+export default config;

--- a/backoffice/tsconfig.json
+++ b/backoffice/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/backoffice/tsconfig.node.json
+++ b/backoffice/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/backoffice/vite.config.ts
+++ b/backoffice/vite.config.ts
@@ -1,0 +1,21 @@
+import { fileURLToPath, URL } from "node:url";
+
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      "@": fileURLToPath(new URL("./src", import.meta.url)),
+    },
+  },
+  server: {
+    host: "0.0.0.0",
+    port: 2050,
+  },
+  preview: {
+    host: "0.0.0.0",
+    port: 4174,
+  },
+});

--- a/bash.sh
+++ b/bash.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+sudo docker-compose down --volumes --remove-orphans
+sudo docker-compose build --no-cache
+sudo docker-compose up -d
+
+printf -- "- **Frontend:** http://localhost:2048\n"
+printf -- "- **Backend API:** http://localhost:2049\n"
+printf -- "- **Backoffice:** http://localhost:2050\n"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,45 @@
+version: "3.9"
+
+services:
+  backend:
+    build:
+      context: .
+      target: backend
+    command: uvicorn backend.app.main:app --host 0.0.0.0 --port 8000 --reload
+    environment:
+      - COURSES_DATA_DIR=/app/json
+    volumes:
+      - ./backend:/app/backend
+      - ./json:/app/json
+    ports:
+      - "2049:8000"
+
+  frontend:
+    build:
+      context: .
+      target: frontend
+    working_dir: /app/frontend
+    command: npm run dev -- --host 0.0.0.0 --port 2048
+    environment:
+      - VITE_API_URL=http://backend:8000
+    volumes:
+      - ./frontend:/app/frontend
+    ports:
+      - "2048:2048"
+    depends_on:
+      - backend
+
+  backoffice:
+    build:
+      context: .
+      target: backoffice
+    working_dir: /app/backoffice
+    command: npm run dev -- --host 0.0.0.0 --port 2050
+    environment:
+      - VITE_API_URL=http://backend:8000
+    volumes:
+      - ./backoffice:/app/backoffice
+    ports:
+      - "2050:2050"
+    depends_on:
+      - backend

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>English Teacher Courses</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "courses-frontend",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite --host 0.0.0.0 --port 2048",
+    "build": "vite build",
+    "preview": "vite preview --host 0.0.0.0 --port 4173"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.2.0",
+    "vite": "^5.1.0"
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,156 @@
+import { useEffect, useMemo, useState } from "react";
+
+const DEFAULT_API = "http://localhost:2049";
+
+function useApiBase() {
+  return useMemo(() => {
+    const base = import.meta.env.VITE_API_URL || DEFAULT_API;
+    return base.replace(/\/$/, "");
+  }, []);
+}
+
+function CourseList({ courses, onSelect, selectedId }) {
+  if (!courses.length) {
+    return <p className="empty">No courses available yet.</p>;
+  }
+
+  return (
+    <ul className="course-list">
+      {courses.map((course) => (
+        <li key={course.id} className={course.id === selectedId ? "active" : ""}>
+          <button type="button" onClick={() => onSelect(course)}>
+            <span className="title">{course.title}</span>
+            {course.tagline && <span className="tagline">{course.tagline}</span>}
+            {course.topics?.length ? (
+              <span className="topics">{course.topics.length} topics</span>
+            ) : null}
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function CourseDetail({ course }) {
+  if (!course) {
+    return (
+      <div className="course-detail placeholder">
+        <h2>Select a course</h2>
+        <p>
+          Choose a course from the list to review its eight sessions, supporting materials, and
+          presentation-ready slide notes.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="course-detail">
+      <header>
+        <h2>{course.title}</h2>
+        {course.metadata.tagline && <p className="tagline">{course.metadata.tagline}</p>}
+        {course.metadata.description && <p className="description">{course.metadata.description}</p>}
+      </header>
+      {course.sessions.length ? (
+        <section>
+          <h3>Session overview</h3>
+          <ol>
+            {course.sessions.map((session) => (
+              <li key={session.id}>
+                <h4>{session.title || session.name}</h4>
+                {session.tagline && <p className="tagline">{session.tagline}</p>}
+                {session.keyIdeas?.length ? (
+                  <ul className="key-ideas">
+                    {session.keyIdeas.map((idea, index) => (
+                      <li key={index}>{idea}</li>
+                    ))}
+                  </ul>
+                ) : null}
+              </li>
+            ))}
+          </ol>
+        </section>
+      ) : (
+        <p>This course does not include any detailed sessions yet.</p>
+      )}
+    </div>
+  );
+}
+
+export default function App() {
+  const apiBase = useApiBase();
+  const [courses, setCourses] = useState([]);
+  const [selectedCourse, setSelectedCourse] = useState(null);
+  const [selectedId, setSelectedId] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [detailLoading, setDetailLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    async function loadCourses() {
+      setLoading(true);
+      setError(null);
+      try {
+        const response = await fetch(`${apiBase}/courses`);
+        if (!response.ok) {
+          throw new Error(`API responded with status ${response.status}`);
+        }
+        const payload = await response.json();
+        setCourses(payload);
+      } catch (err) {
+        setError(err.message);
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    loadCourses();
+  }, [apiBase]);
+
+  async function handleSelect(course) {
+    setSelectedId(course.id);
+    setDetailLoading(true);
+    setError(null);
+    try {
+      const response = await fetch(`${apiBase}/courses/${course.slug || course.id}`);
+      if (!response.ok) {
+        throw new Error(`Failed to load course ${course.id}`);
+      }
+      const payload = await response.json();
+      setSelectedCourse(payload);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setDetailLoading(false);
+    }
+  }
+
+  return (
+    <div className="app-shell">
+      <aside>
+        <div className="panel">
+          <h1>English Teacher</h1>
+          <p className="intro">
+            Browse the library of business-focused English courses. Every syllabus follows an eight-session
+            flow with presentation-ready content.
+          </p>
+        </div>
+        <div className="panel list">
+          <div className="panel-header">
+            <h2>Courses</h2>
+            {loading && <span className="status">Loading…</span>}
+          </div>
+          {error && <p className="error">{error}</p>}
+          {!loading && !error && (
+            <CourseList courses={courses} onSelect={handleSelect} selectedId={selectedId} />
+          )}
+        </div>
+      </aside>
+      <main>
+        {detailLoading && <p className="status">Loading course details…</p>}
+        {!detailLoading && !error && <CourseDetail course={selectedCourse} />}
+        {!detailLoading && error && <p className="error">{error}</p>}
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,204 @@
+:root {
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  line-height: 1.5;
+  color: #1f2933;
+  background-color: #f5f7fa;
+}
+
+body {
+  margin: 0;
+}
+
+button {
+  font: inherit;
+}
+
+.app-shell {
+  min-height: 100vh;
+  display: grid;
+  grid-template-columns: minmax(280px, 340px) 1fr;
+}
+
+aside {
+  background: #10172a;
+  color: #f9fafb;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 2rem 1.5rem;
+}
+
+.panel {
+  background: rgba(15, 23, 42, 0.55);
+  padding: 1.25rem;
+  border-radius: 1rem;
+  box-shadow: 0 12px 40px rgba(15, 23, 42, 0.35);
+}
+
+.panel h1 {
+  margin-top: 0;
+  font-size: 1.75rem;
+}
+
+.panel .intro {
+  margin: 0.75rem 0 0;
+  font-size: 0.95rem;
+  color: rgba(248, 250, 252, 0.85);
+}
+
+.panel.list {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.75rem;
+}
+
+.panel-header h2 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.status {
+  font-size: 0.85rem;
+  color: rgba(148, 163, 184, 0.95);
+}
+
+.course-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  overflow-y: auto;
+}
+
+.course-list li button {
+  width: 100%;
+  border: 1px solid transparent;
+  background: rgba(15, 23, 42, 0.35);
+  color: inherit;
+  border-radius: 0.75rem;
+  text-align: left;
+  padding: 0.75rem 1rem;
+  transition: background 120ms ease, border 120ms ease;
+}
+
+.course-list li.active button,
+.course-list li button:hover {
+  background: rgba(15, 23, 42, 0.55);
+  border-color: rgba(94, 234, 212, 0.3);
+}
+
+.course-list .title {
+  display: block;
+  font-weight: 600;
+}
+
+.course-list .tagline {
+  display: block;
+  font-size: 0.85rem;
+  color: rgba(148, 163, 184, 0.95);
+}
+
+.course-list .topics {
+  display: inline-block;
+  margin-top: 0.35rem;
+  font-size: 0.75rem;
+  color: rgba(248, 250, 252, 0.8);
+  background: rgba(94, 234, 212, 0.2);
+  padding: 0.25rem 0.5rem;
+  border-radius: 999px;
+}
+
+main {
+  padding: 2.5rem 3rem;
+}
+
+.course-detail {
+  max-width: 860px;
+}
+
+.course-detail header h2 {
+  margin: 0;
+  font-size: 2.25rem;
+  color: #0f172a;
+}
+
+.course-detail header .tagline {
+  font-size: 1.1rem;
+  color: #475569;
+  margin: 0.5rem 0 0;
+}
+
+.course-detail header .description {
+  margin-top: 0.75rem;
+  color: #1f2937;
+}
+
+.course-detail section {
+  margin-top: 2rem;
+}
+
+.course-detail ol {
+  margin: 0;
+  padding-left: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.course-detail li h4 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.key-ideas {
+  margin: 0.5rem 0 0;
+  padding-left: 1rem;
+  color: #475569;
+  font-size: 0.95rem;
+}
+
+.error {
+  color: #fbbf24;
+  font-size: 0.9rem;
+}
+
+.empty {
+  color: rgba(148, 163, 184, 0.95);
+}
+
+.placeholder {
+  color: #475569;
+  background: #fff;
+  border-radius: 1rem;
+  padding: 2rem;
+  box-shadow: 0 24px 40px rgba(15, 23, 42, 0.08);
+}
+
+@media (max-width: 960px) {
+  .app-shell {
+    grid-template-columns: 1fr;
+  }
+
+  aside {
+    flex-direction: row;
+    align-items: stretch;
+    overflow-x: auto;
+  }
+
+  aside .panel {
+    min-width: 260px;
+  }
+
+  main {
+    padding: 2rem;
+  }
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,10 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App.jsx";
+import "./index.css";
+
+ReactDOM.createRoot(document.getElementById("root")).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,14 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    host: "0.0.0.0",
+    port: 2048,
+  },
+  preview: {
+    host: "0.0.0.0",
+    port: 4173,
+  },
+});


### PR DESCRIPTION
## Summary
- add a FastAPI backend that reads the existing course JSON catalogue and exposes health, list, and detail endpoints
- scaffold React/Vite frontend and shadcn-driven backoffice surfaces that consume the API
- wire up a multi-stage Dockerfile, docker-compose stack, helper script, and README updates so all three apps run on ports 2048-2050

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d17ad511ac832586afbe3c8bceebed