### PR TITLE
Add Top100 management interface and API

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,11 +1,19 @@
-"""FastAPI application exposing course data endpoints."""
+"""FastAPI application exposing course data endpoints and Top100 editor."""
 from __future__ import annotations
 
 import os
-from typing import List
+import re
+import uuid
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Literal, Optional
 
-from fastapi import Depends, FastAPI, Query
+from fastapi import Depends, FastAPI, HTTPException, Query, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import HTMLResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+from pydantic import BaseModel, Field
 
 from .models import CourseDetail, CourseSummary
 from .storage import CourseStore, discover_data_directory
@@ -17,6 +25,11 @@ def get_store() -> CourseStore:
     return CourseStore(directory)
 
 
+BASE_DIR = Path(__file__).parent
+TEMPLATES_DIR = BASE_DIR / "templates"
+STATIC_DIR = BASE_DIR / "static"
+
+
 app = FastAPI(title="Courses API", version="1.0.0")
 
 app.add_middleware(
@@ -26,6 +39,11 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+if STATIC_DIR.exists():
+    app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")
+
+templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
 
 
 @app.get("/", summary="Service information")
@@ -42,7 +60,10 @@ def healthcheck() -> dict[str, str]:
 
 
 @app.get("/courses", response_model=List[CourseSummary], summary="List courses")
-def list_courses(store: CourseStore = Depends(get_store), search: str | None = Query(default=None)) -> List[CourseSummary]:
+def list_courses(
+    store: CourseStore = Depends(get_store),
+    search: str | None = Query(default=None),
+) -> List[CourseSummary]:
     if search:
         return store.search(search)
     return store.list_courses()
@@ -55,3 +76,160 @@ def list_courses(store: CourseStore = Depends(get_store), search: str | None = Q
 )
 def get_course(identifier: str, store: CourseStore = Depends(get_store)) -> CourseDetail:
     return store.get_course(identifier)
+
+
+ClipStatus = Literal["todo", "queued", "rendering", "done", "error"]
+
+
+class TopItem(BaseModel):
+    rank: int = Field(ge=1, le=100)
+    title: str
+    tagline: str
+    image_url: Optional[str] = None
+    clip_status: ClipStatus = "todo"
+    clip_url: Optional[str] = None
+    source: Literal["library", "generated"] = "library"
+
+
+class Top100(BaseModel):
+    slug: str
+    topic: str
+    personality: str
+    description: Optional[str] = ""
+    items: List[TopItem] = Field(default_factory=list)
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+STORE: Dict[str, Top100] = {}
+
+
+def slugify(value: str) -> str:
+    slug = re.sub(r"[^a-zA-Z0-9\- ]+", "", value)
+    slug = slug.strip().lower().replace(" ", "-")
+    return re.sub(r"-+", "-", slug)
+
+
+@app.get("/top100", response_class=HTMLResponse)
+def top100_index(request: Request) -> HTMLResponse:
+    sets = sorted(STORE.values(), key=lambda data: data.updated_at, reverse=True)
+    return templates.TemplateResponse(
+        "top100_index.html",
+        {
+            "request": request,
+            "sets": sets,
+        },
+    )
+
+
+@app.get("/top100/new", response_class=HTMLResponse)
+def top100_new(request: Request) -> HTMLResponse:
+    return templates.TemplateResponse(
+        "top100_edit.html",
+        {
+            "request": request,
+            "payload": None,
+        },
+    )
+
+
+@app.get("/top100/{slug}", response_class=HTMLResponse)
+def top100_edit(slug: str, request: Request) -> HTMLResponse:
+    data = STORE.get(slug)
+    if not data:
+        raise HTTPException(status_code=404, detail="Top100 not found")
+    return templates.TemplateResponse(
+        "top100_edit.html",
+        {
+            "request": request,
+            "payload": data.model_dump(),
+        },
+    )
+
+
+@app.get("/api/top100/{slug}")
+def api_get_top100(slug: str) -> Top100:
+    data = STORE.get(slug)
+    if not data:
+        raise HTTPException(status_code=404, detail="Top100 not found")
+    return data
+
+
+class CreateTopRequest(BaseModel):
+    topic: str
+    personality: str
+    description: Optional[str] = ""
+    items: Optional[List[TopItem]] = None
+
+
+@app.post("/api/top100")
+def api_create_top100(req: CreateTopRequest) -> dict[str, str | bool]:
+    slug = slugify(f"{req.topic}-{req.personality}-{uuid.uuid4().hex[:6]}")
+    if req.items is not None and len(req.items) != 100:
+        raise HTTPException(status_code=400, detail="items must be exactly 100")
+    items = req.items or [
+        TopItem(
+            rank=index + 1,
+            title=f"Item {index + 1}",
+            tagline=f"One-liner for {req.topic} #{index + 1}",
+        )
+        for index in range(100)
+    ]
+    data = Top100(
+        slug=slug,
+        topic=req.topic,
+        personality=req.personality,
+        description=req.description,
+        items=items,
+    )
+    STORE[slug] = data
+    return {"ok": True, "slug": slug}
+
+
+class UpdateTopRequest(BaseModel):
+    topic: Optional[str] = None
+    personality: Optional[str] = None
+    description: Optional[str] = None
+    items: Optional[List[TopItem]] = None
+
+
+@app.post("/api/top100/{slug}")
+def api_update_top100(slug: str, req: UpdateTopRequest) -> dict[str, str | bool]:
+    data = STORE.get(slug)
+    if not data:
+        raise HTTPException(status_code=404, detail="Top100 not found")
+    if req.topic is not None:
+        data.topic = req.topic
+    if req.personality is not None:
+        data.personality = req.personality
+    if req.description is not None:
+        data.description = req.description
+    if req.items is not None:
+        if len(req.items) != 100:
+            raise HTTPException(status_code=400, detail="items must be exactly 100")
+        data.items = req.items
+    data.updated_at = datetime.utcnow()
+    STORE[slug] = data
+    return {"ok": True, "slug": slug}
+
+
+class GenerateRequest(BaseModel):
+    mode: Literal["library", "generate", "mixed"] = "mixed"
+    seconds_per_clip: int = 10
+
+
+@app.post("/api/top100/{slug}/generate")
+def api_generate(slug: str, req: GenerateRequest) -> dict[str, int | str | bool]:
+    data = STORE.get(slug)
+    if not data:
+        raise HTTPException(status_code=404, detail="Top100 not found")
+    for index, item in enumerate(data.items):
+        data.items[index] = item.model_copy(update={"clip_status": "queued"})
+    data.updated_at = datetime.utcnow()
+    STORE[slug] = data
+    return {
+        "ok": True,
+        "queued": len(data.items),
+        "seconds_per_clip": req.seconds_per_clip,
+        "mode": req.mode,
+    }

--- a/backend/app/templates/top100_edit.html
+++ b/backend/app/templates/top100_edit.html
@@ -1,0 +1,143 @@
+<!doctype html>
+<html x-data="Top100Editor()" x-init="init()" class="h-full">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.4/dist/tailwind.min.css">
+  <title>VAD · Top100 Editor</title>
+</head>
+<body class="bg-neutral-950 text-neutral-100 h-full">
+  <header class="sticky top-0 z-20 bg-neutral-900/80 backdrop-blur border-b border-neutral-800">
+    <div class="max-w-6xl mx-auto px-4 py-3 flex flex-wrap gap-2 items-center">
+      <a href="/top100" class="text-sm text-neutral-400 hover:text-neutral-200">← All sets</a>
+      <div class="grow"></div>
+      <input x-model="topic" placeholder="Topic (e.g., World’s Best Beaches)" class="px-3 py-1.5 bg-neutral-800 rounded-xl w-64"/>
+      <input x-model="personality" placeholder="Personality (e.g., Gorai)" class="px-3 py-1.5 bg-neutral-800 rounded-xl w-48"/>
+      <button @click="save()" class="px-3 py-1.5 rounded-xl bg-neutral-200 text-neutral-900 hover:bg-white">Save</button>
+      <button @click="exportJson()" class="px-3 py-1.5 rounded-xl bg-neutral-800 hover:bg-neutral-700">Export JSON</button>
+      <label class="px-3 py-1.5 rounded-xl bg-neutral-800 hover:bg-neutral-700 cursor-pointer">
+        Import JSON<input type="file" class="hidden" @change="importJson($event)"/>
+      </label>
+      <button @click="generate()" class="px-3 py-1.5 rounded-xl bg-emerald-400 text-emerald-950 hover:bg-emerald-300">Generate 100 Clips</button>
+    </div>
+  </header>
+
+  <main class="max-w-6xl mx-auto px-4 py-6 space-y-4">
+    <textarea x-model="description" rows="2" placeholder="Short description..." class="w-full bg-neutral-900 border border-neutral-800 rounded-2xl p-3"></textarea>
+
+    <div class="text-sm text-neutral-400">Items: <span class="text-neutral-200 font-medium" x-text="items.length"></span>/100</div>
+
+    <div class="overflow-x-auto border border-neutral-800 rounded-2xl">
+      <table class="w-full text-sm">
+        <thead class="bg-neutral-900 text-neutral-300">
+          <tr>
+            <th class="p-2 text-left">#</th>
+            <th class="p-2 text-left">Title</th>
+            <th class="p-2 text-left">One-liner (voiceover base)</th>
+            <th class="p-2 text-left">Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          <template x-for="(it, idx) in items" :key="it.rank">
+            <tr class="border-t border-neutral-800">
+              <td class="p-2 w-10" x-text="it.rank"></td>
+              <td class="p-2"><input class="w-full bg-neutral-900 rounded-lg p-1.5" x-model="it.title" placeholder="Title"/></td>
+              <td class="p-2"><input class="w-full bg-neutral-900 rounded-lg p-1.5" x-model="it.tagline" placeholder="Short, punchy one-liner"/></td>
+              <td class="p-2">
+                <span class="px-2 py-1 rounded-lg border border-neutral-700" x-text="it.clip_status"></span>
+              </td>
+            </tr>
+          </template>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="flex items-center gap-2">
+      <button @click="fillBlank()" class="px-3 py-1.5 rounded-xl bg-neutral-800 hover:bg-neutral-700">Autofill empty rows</button>
+      <button @click="reset()" class="px-3 py-1.5 rounded-xl bg-neutral-800 hover:bg-neutral-700">Reset 100 rows</button>
+    </div>
+  </main>
+
+  <script>
+    function Top100Editor(){
+      return {
+        slug: null,
+        topic: "",
+        personality: "",
+        description: "",
+        items: [],
+        init(){
+          const payload = {{ payload | tojson | safe }};
+          if(payload){
+            this.slug = payload.slug;
+            this.topic = payload.topic;
+            this.personality = payload.personality;
+            this.description = payload.description || "";
+            this.items = payload.items || [];
+          } else {
+            this.reset();
+          }
+        },
+        reset(){
+          this.items = Array.from({length:100}, (_,i)=>({
+            rank: i+1, title: `Item ${i+1}`, tagline: `One-liner for item ${i+1}`, image_url: null, clip_status: "todo", clip_url: null, source: "library"
+          }));
+        },
+        fillBlank(){
+          this.items = this.items.map((it, i)=>({
+            ...it,
+            title: it.title && it.title.trim() ? it.title : `Item ${i+1}`,
+            tagline: it.tagline && it.tagline.trim() ? it.tagline : `One-liner for ${this.topic || 'topic'} #${i+1}`
+          }));
+        },
+        async save(){
+          const body = {
+            topic: this.topic, personality: this.personality,
+            description: this.description, items: this.items
+          };
+          if(!this.slug){
+            const res = await fetch("/api/top100",{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify(body)});
+            const j = await res.json();
+            if(j.ok){ this.slug = j.slug; window.history.replaceState({}, "", `/top100/${this.slug}`); alert("Saved."); }
+          } else {
+            const res = await fetch(`/api/top100/${this.slug}`,{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify(body)});
+            const j = await res.json();
+            if(j.ok){ alert("Updated."); }
+          }
+        },
+        exportJson(){
+          const obj = { slug: this.slug, topic: this.topic, personality: this.personality, description: this.description, items: this.items };
+          const blob = new Blob([JSON.stringify(obj, null, 2)], {type:"application/json"});
+          const a = document.createElement("a");
+          a.href = URL.createObjectURL(blob);
+          a.download = `${(this.topic||'top100')}-${(this.personality||'persona')}.json`;
+          a.click();
+        },
+        importJson(ev){
+          const file = ev.target.files[0];
+          if(!file) return;
+          const fr = new FileReader();
+          fr.onload = () => {
+            try{
+              const j = JSON.parse(fr.result);
+              this.slug = j.slug || this.slug;
+              this.topic = j.topic || this.topic;
+              this.personality = j.personality || this.personality;
+              this.description = j.description || this.description;
+              if(Array.isArray(j.items) && j.items.length===100){ this.items = j.items; }
+            }catch(e){ alert("Invalid JSON"); }
+          };
+          fr.readAsText(file);
+        },
+        async generate(){
+          if(!this.slug){ await this.save(); }
+          const res = await fetch(`/api/top100/${this.slug}/generate`, {method:"POST", headers:{"Content-Type":"application/json"}, body: JSON.stringify({mode:"mixed", seconds_per_clip:10})});
+          const j = await res.json();
+          if(j.ok){ this.items = this.items.map(it=>({...it, clip_status:"queued"})); alert("Queued 100 × 10s clips."); }
+        }
+      }
+    }
+  </script>
+</body>
+</html>

--- a/backend/app/templates/top100_index.html
+++ b/backend/app/templates/top100_index.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <script defer src="https://unpkg.com/htmx.org@1.9.12"></script>
+  <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.4/dist/tailwind.min.css">
+  <title>VAD · Top100</title>
+</head>
+<body class="bg-neutral-950 text-neutral-100">
+  <header class="sticky top-0 z-20 bg-neutral-900/80 backdrop-blur border-b border-neutral-800">
+    <div class="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between">
+      <h1 class="text-xl font-semibold">Top100 Sets</h1>
+      <a href="/top100/new" class="px-3 py-1.5 rounded-xl bg-neutral-200 text-neutral-900 hover:bg-white">New Top100</a>
+    </div>
+  </header>
+
+  <main class="max-w-5xl mx-auto px-4 py-6 space-y-4">
+    {% if sets|length == 0 %}
+      <p class="text-neutral-400">No Top100 sets yet. Click “New Top100”.</p>
+    {% else %}
+      <ul class="grid gap-3">
+        {% for s in sets %}
+        <li class="border border-neutral-800 rounded-2xl p-4 hover:bg-neutral-900">
+          <a class="block" href="/top100/{{ s.slug }}">
+            <div class="text-lg font-medium">{{ s.topic }} · {{ s.personality }}</div>
+            <div class="text-sm text-neutral-400">/{{ s.slug }} — {{ s.items|length }} items — updated {{ s.updated_at }}</div>
+          </a>
+        </li>
+        {% endfor %}
+      </ul>
+    {% endif %}
+  </main>
+</body>
+</html>

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,3 +1,4 @@
 fastapi==0.109.2
 uvicorn[standard]==0.27.1
 python-multipart==0.0.9
+Jinja2==3.1.4


### PR DESCRIPTION
## Summary
- extend the FastAPI app with Top100 data models, CRUD endpoints, and generation queue stub
- add Tailwind-powered Jinja templates for the Top100 list and editor pages plus a static mount point
- declare the Jinja2 dependency required for rendering the new templates

## Testing
- python -m compileall backend/app/main.py
- pip install -r backend/requirements.txt *(fails to fetch Jinja2 because the environment blocks proxy access)*

------
https://chatgpt.com/codex/tasks/task_e_68e6222d42588325b6fb7366049250e2