### PR TITLE
Refresh Top100 UI with shared layout

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,11 +1,19 @@
-"""FastAPI application exposing course data endpoints."""
+"""FastAPI application exposing course data endpoints and Top100 editor."""
 from __future__ import annotations
 
 import os
-from typing import List
+import re
+import uuid
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Literal, Optional
 
-from fastapi import Depends, FastAPI, Query
+from fastapi import Depends, FastAPI, HTTPException, Query, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import HTMLResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+from pydantic import BaseModel, Field
 
 from .models import CourseDetail, CourseSummary
 from .storage import CourseStore, discover_data_directory
@@ -17,6 +25,11 @@ def get_store() -> CourseStore:
     return CourseStore(directory)
 
 
+BASE_DIR = Path(__file__).parent
+TEMPLATES_DIR = BASE_DIR / "templates"
+STATIC_DIR = BASE_DIR / "static"
+
+
 app = FastAPI(title="Courses API", version="1.0.0")
 
 app.add_middleware(
@@ -26,6 +39,11 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+if STATIC_DIR.exists():
+    app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")
+
+templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
 
 
 @app.get("/", summary="Service information")
@@ -42,7 +60,10 @@ def healthcheck() -> dict[str, str]:
 
 
 @app.get("/courses", response_model=List[CourseSummary], summary="List courses")
-def list_courses(store: CourseStore = Depends(get_store), search: str | None = Query(default=None)) -> List[CourseSummary]:
+def list_courses(
+    store: CourseStore = Depends(get_store),
+    search: str | None = Query(default=None),
+) -> List[CourseSummary]:
     if search:
         return store.search(search)
     return store.list_courses()
@@ -55,3 +76,163 @@ def list_courses(store: CourseStore = Depends(get_store), search: str | None = Q
 )
 def get_course(identifier: str, store: CourseStore = Depends(get_store)) -> CourseDetail:
     return store.get_course(identifier)
+
+
+ClipStatus = Literal["todo", "queued", "rendering", "done", "error"]
+
+
+class TopItem(BaseModel):
+    rank: int = Field(ge=1, le=100)
+    title: str
+    tagline: str
+    image_url: Optional[str] = None
+    clip_status: ClipStatus = "todo"
+    clip_url: Optional[str] = None
+    source: Literal["library", "generated"] = "library"
+
+
+class Top100(BaseModel):
+    slug: str
+    topic: str
+    personality: str
+    description: Optional[str] = ""
+    items: List[TopItem] = Field(default_factory=list)
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+STORE: Dict[str, Top100] = {}
+
+
+def slugify(value: str) -> str:
+    slug = re.sub(r"[^a-zA-Z0-9\- ]+", "", value)
+    slug = slug.strip().lower().replace(" ", "-")
+    return re.sub(r"-+", "-", slug)
+
+
+@app.get("/top100", response_class=HTMLResponse)
+def top100_index(request: Request) -> HTMLResponse:
+    sets = sorted(STORE.values(), key=lambda data: data.updated_at, reverse=True)
+    return templates.TemplateResponse(
+        "top100_index.html",
+        {
+            "request": request,
+            "sets": sets,
+            "active_page": "top100",
+        },
+    )
+
+
+@app.get("/top100/new", response_class=HTMLResponse)
+def top100_new(request: Request) -> HTMLResponse:
+    return templates.TemplateResponse(
+        "top100_edit.html",
+        {
+            "request": request,
+            "payload": None,
+            "active_page": "top100",
+        },
+    )
+
+
+@app.get("/top100/{slug}", response_class=HTMLResponse)
+def top100_edit(slug: str, request: Request) -> HTMLResponse:
+    data = STORE.get(slug)
+    if not data:
+        raise HTTPException(status_code=404, detail="Top100 not found")
+    return templates.TemplateResponse(
+        "top100_edit.html",
+        {
+            "request": request,
+            "payload": data.model_dump(),
+            "active_page": "top100",
+        },
+    )
+
+
+@app.get("/api/top100/{slug}")
+def api_get_top100(slug: str) -> Top100:
+    data = STORE.get(slug)
+    if not data:
+        raise HTTPException(status_code=404, detail="Top100 not found")
+    return data
+
+
+class CreateTopRequest(BaseModel):
+    topic: str
+    personality: str
+    description: Optional[str] = ""
+    items: Optional[List[TopItem]] = None
+
+
+@app.post("/api/top100")
+def api_create_top100(req: CreateTopRequest) -> dict[str, str | bool]:
+    slug = slugify(f"{req.topic}-{req.personality}-{uuid.uuid4().hex[:6]}")
+    if req.items is not None and len(req.items) != 100:
+        raise HTTPException(status_code=400, detail="items must be exactly 100")
+    items = req.items or [
+        TopItem(
+            rank=index + 1,
+            title=f"Item {index + 1}",
+            tagline=f"One-liner for {req.topic} #{index + 1}",
+        )
+        for index in range(100)
+    ]
+    data = Top100(
+        slug=slug,
+        topic=req.topic,
+        personality=req.personality,
+        description=req.description,
+        items=items,
+    )
+    STORE[slug] = data
+    return {"ok": True, "slug": slug}
+
+
+class UpdateTopRequest(BaseModel):
+    topic: Optional[str] = None
+    personality: Optional[str] = None
+    description: Optional[str] = None
+    items: Optional[List[TopItem]] = None
+
+
+@app.post("/api/top100/{slug}")
+def api_update_top100(slug: str, req: UpdateTopRequest) -> dict[str, str | bool]:
+    data = STORE.get(slug)
+    if not data:
+        raise HTTPException(status_code=404, detail="Top100 not found")
+    if req.topic is not None:
+        data.topic = req.topic
+    if req.personality is not None:
+        data.personality = req.personality
+    if req.description is not None:
+        data.description = req.description
+    if req.items is not None:
+        if len(req.items) != 100:
+            raise HTTPException(status_code=400, detail="items must be exactly 100")
+        data.items = req.items
+    data.updated_at = datetime.utcnow()
+    STORE[slug] = data
+    return {"ok": True, "slug": slug}
+
+
+class GenerateRequest(BaseModel):
+    mode: Literal["library", "generate", "mixed"] = "mixed"
+    seconds_per_clip: int = 10
+
+
+@app.post("/api/top100/{slug}/generate")
+def api_generate(slug: str, req: GenerateRequest) -> dict[str, int | str | bool]:
+    data = STORE.get(slug)
+    if not data:
+        raise HTTPException(status_code=404, detail="Top100 not found")
+    for index, item in enumerate(data.items):
+        data.items[index] = item.model_copy(update={"clip_status": "queued"})
+    data.updated_at = datetime.utcnow()
+    STORE[slug] = data
+    return {
+        "ok": True,
+        "queued": len(data.items),
+        "seconds_per_clip": req.seconds_per_clip,
+        "mode": req.mode,
+    }

--- a/backend/app/templates/layout.html
+++ b/backend/app/templates/layout.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en" class="h-full">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.4/dist/tailwind.min.css" />
+  <title>{% block title %}English Teacher{% endblock %}</title>
+  {% block head_extra %}{% endblock %}
+</head>
+<body class="flex min-h-screen flex-col bg-slate-50 text-slate-900">
+  <header class="sticky top-0 z-30 border-b border-slate-200 bg-white/90 backdrop-blur">
+    <div class="mx-auto flex w-full max-w-6xl items-center justify-between gap-4 px-4 py-4">
+      <a href="/" class="text-lg font-semibold tracking-tight text-slate-900 transition hover:text-slate-600">English Teacher</a>
+      <nav class="flex items-center gap-1 text-sm font-medium text-slate-600">
+        {% set nav_links = [
+          ("API Docs", "/docs", "docs"),
+          ("Top100", "/top100", "top100")
+        ] %}
+        {% for label, href, key in nav_links %}
+          <a
+            href="{{ href }}"
+            class="rounded-full px-3 py-1.5 transition hover:bg-slate-900/5 hover:text-slate-900 {% if active_page == key %}bg-slate-900 text-white hover:text-white{% endif %}"
+          >{{ label }}</a>
+        {% endfor %}
+      </nav>
+    </div>
+  </header>
+
+  <main class="flex-1">
+    {% block content %}{% endblock %}
+  </main>
+
+  <footer class="sticky bottom-0 border-t border-slate-200 bg-white/90">
+    <div class="mx-auto flex w-full max-w-6xl items-center justify-between gap-4 px-4 py-3 text-xs text-slate-500">
+      <span>English Teacher · Course tooling</span>
+      <span>Eight-session format · JSON-first</span>
+    </div>
+  </footer>
+
+  {% block body_scripts %}{% endblock %}
+</body>
+</html>

--- a/backend/app/templates/top100_edit.html
+++ b/backend/app/templates/top100_edit.html
@@ -1,0 +1,204 @@
+{% extends "layout.html" %}
+
+{% block title %}Top100 Editor · English Teacher{% endblock %}
+
+{% block head_extra %}
+  <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
+{% endblock %}
+
+{% block content %}
+<section x-data="Top100Editor()" x-init="init()" class="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 py-10">
+  <div class="flex flex-wrap items-center gap-3 text-sm text-slate-500">
+    <a href="/top100" class="inline-flex items-center gap-1 rounded-full border border-slate-200 bg-white px-3 py-1.5 text-slate-600 transition hover:border-slate-300 hover:text-slate-900">
+      <span aria-hidden="true">←</span>
+      All sets
+    </a>
+    <span class="hidden sm:block">Manage a ranked list of one hundred clips for automated rendering.</span>
+  </div>
+
+  <div class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+    <div class="flex w-full flex-wrap items-center gap-3">
+      <input
+        x-model="topic"
+        placeholder="Topic (e.g., World’s Best Beaches)"
+        class="min-w-[220px] flex-1 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm transition focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200"
+        type="text"
+      />
+      <input
+        x-model="personality"
+        placeholder="Personality (e.g., Gorai)"
+        class="min-w-[180px] flex-1 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm transition focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200 sm:flex-none sm:w-48"
+        type="text"
+      />
+      <div class="ml-auto flex flex-wrap items-center gap-2">
+        <button
+          @click="save()"
+          class="inline-flex items-center justify-center rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-slate-700"
+          type="button"
+        >Save</button>
+        <button
+          @click="exportJson()"
+          class="inline-flex items-center justify-center rounded-full border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-300 hover:text-slate-900"
+          type="button"
+        >Export JSON</button>
+        <label class="inline-flex items-center justify-center gap-2 rounded-full border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-300 hover:text-slate-900">
+          Import JSON
+          <input type="file" class="hidden" @change="importJson($event)" />
+        </label>
+        <button
+          @click="generate()"
+          class="inline-flex items-center justify-center rounded-full bg-emerald-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-emerald-400"
+          type="button"
+        >Generate 100 Clips</button>
+      </div>
+    </div>
+  </div>
+
+  <textarea
+    x-model="description"
+    rows="2"
+    placeholder="Short description..."
+    class="w-full rounded-2xl border border-slate-200 bg-white p-4 text-sm text-slate-900 shadow-sm transition focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200"
+  ></textarea>
+
+  <div class="flex items-center justify-between text-sm text-slate-600">
+    <span>Items: <span class="font-semibold text-slate-900" x-text="items.length"></span>/100</span>
+    <div class="flex items-center gap-2">
+      <button
+        @click="fillBlank()"
+        class="inline-flex items-center justify-center rounded-full border border-slate-200 px-3 py-1.5 text-xs font-semibold uppercase tracking-wide text-slate-700 transition hover:border-slate-300 hover:text-slate-900"
+        type="button"
+      >Autofill empty rows</button>
+      <button
+        @click="reset()"
+        class="inline-flex items-center justify-center rounded-full border border-slate-200 px-3 py-1.5 text-xs font-semibold uppercase tracking-wide text-slate-700 transition hover:border-slate-300 hover:text-slate-900"
+        type="button"
+      >Reset 100 rows</button>
+    </div>
+  </div>
+
+  <div class="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+    <div class="overflow-x-auto">
+      <table class="min-w-full divide-y divide-slate-200 text-sm text-slate-700">
+        <thead class="bg-slate-50 text-xs font-semibold uppercase tracking-wide text-slate-500">
+          <tr>
+            <th class="px-3 py-2 text-left">#</th>
+            <th class="px-3 py-2 text-left">Title</th>
+            <th class="px-3 py-2 text-left">One-liner (voiceover base)</th>
+            <th class="px-3 py-2 text-left">Status</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-slate-100">
+          <template x-for="(it, idx) in items" :key="it.rank">
+            <tr class="hover:bg-slate-50/80">
+              <td class="px-3 py-2 text-slate-500" x-text="it.rank"></td>
+              <td class="px-3 py-2">
+                <input
+                  class="w-full rounded-lg border border-slate-200 bg-white px-2 py-1.5 text-sm text-slate-900 transition focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200"
+                  x-model="it.title"
+                  placeholder="Title"
+                  type="text"
+                />
+              </td>
+              <td class="px-3 py-2">
+                <input
+                  class="w-full rounded-lg border border-slate-200 bg-white px-2 py-1.5 text-sm text-slate-900 transition focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200"
+                  x-model="it.tagline"
+                  placeholder="Short, punchy one-liner"
+                  type="text"
+                />
+              </td>
+              <td class="px-3 py-2">
+                <span class="inline-flex items-center rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-600" x-text="it.clip_status"></span>
+              </td>
+            </tr>
+          </template>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</section>
+{% endblock %}
+
+{% block body_scripts %}
+  <script>
+    function Top100Editor(){
+      return {
+        slug: null,
+        topic: "",
+        personality: "",
+        description: "",
+        items: [],
+        init(){
+          const payload = {{ payload | tojson | safe }};
+          if(payload){
+            this.slug = payload.slug;
+            this.topic = payload.topic;
+            this.personality = payload.personality;
+            this.description = payload.description || "";
+            this.items = payload.items || [];
+          } else {
+            this.reset();
+          }
+        },
+        reset(){
+          this.items = Array.from({length:100}, (_,i)=>({
+            rank: i+1, title: `Item ${i+1}`, tagline: `One-liner for item ${i+1}`, image_url: null, clip_status: "todo", clip_url: null, source: "library"
+          }));
+        },
+        fillBlank(){
+          this.items = this.items.map((it, i)=>({
+            ...it,
+            title: it.title && it.title.trim() ? it.title : `Item ${i+1}`,
+            tagline: it.tagline && it.tagline.trim() ? it.tagline : `One-liner for ${this.topic || 'topic'} #${i+1}`
+          }));
+        },
+        async save(){
+          const body = {
+            topic: this.topic, personality: this.personality,
+            description: this.description, items: this.items
+          };
+          if(!this.slug){
+            const res = await fetch("/api/top100",{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify(body)});
+            const j = await res.json();
+            if(j.ok){ this.slug = j.slug; window.history.replaceState({}, "", `/top100/${this.slug}`); alert("Saved."); }
+          } else {
+            const res = await fetch(`/api/top100/${this.slug}`,{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify(body)});
+            const j = await res.json();
+            if(j.ok){ alert("Updated."); }
+          }
+        },
+        exportJson(){
+          const obj = { slug: this.slug, topic: this.topic, personality: this.personality, description: this.description, items: this.items };
+          const blob = new Blob([JSON.stringify(obj, null, 2)], {type:"application/json"});
+          const a = document.createElement("a");
+          a.href = URL.createObjectURL(blob);
+          a.download = `${(this.topic||'top100')}-${(this.personality||'persona')}.json`;
+          a.click();
+        },
+        importJson(ev){
+          const file = ev.target.files[0];
+          if(!file) return;
+          const fr = new FileReader();
+          fr.onload = () => {
+            try{
+              const j = JSON.parse(fr.result);
+              this.slug = j.slug || this.slug;
+              this.topic = j.topic || this.topic;
+              this.personality = j.personality || this.personality;
+              this.description = j.description || this.description;
+              if(Array.isArray(j.items) && j.items.length===100){ this.items = j.items; }
+            }catch(e){ alert("Invalid JSON"); }
+          };
+          fr.readAsText(file);
+        },
+        async generate(){
+          if(!this.slug){ await this.save(); }
+          const res = await fetch(`/api/top100/${this.slug}/generate`, {method:"POST", headers:{"Content-Type":"application/json"}, body: JSON.stringify({mode:"mixed", seconds_per_clip:10})});
+          const j = await res.json();
+          if(j.ok){ this.items = this.items.map(it=>({...it, clip_status:"queued"})); alert("Queued 100 × 10s clips."); }
+        }
+      }
+    }
+  </script>
+{% endblock %}

--- a/backend/app/templates/top100_index.html
+++ b/backend/app/templates/top100_index.html
@@ -1,0 +1,43 @@
+{% extends "layout.html" %}
+
+{% block title %}Top100 Sets · English Teacher{% endblock %}
+
+{% block content %}
+<section class="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 py-10">
+  <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+    <div class="space-y-1">
+      <h1 class="text-2xl font-semibold tracking-tight text-slate-900">Top100 sets</h1>
+      <p class="text-sm text-slate-500">Batch plan one hundred short clips per topic and personality.</p>
+    </div>
+    <a
+      href="/top100/new"
+      class="inline-flex items-center justify-center rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-700"
+    >New Top100</a>
+  </div>
+
+  {% if sets|length == 0 %}
+    <p class="rounded-2xl border border-dashed border-slate-200 bg-white p-6 text-sm text-slate-500">
+      No Top100 sets yet. Start by creating a new collection to import or generate one hundred clips.
+    </p>
+  {% else %}
+    <ul class="grid gap-4">
+      {% for s in sets %}
+        <li>
+          <a
+            class="block rounded-2xl border border-slate-200 bg-white p-5 shadow-sm transition hover:-translate-y-0.5 hover:border-slate-300 hover:shadow-md"
+            href="/top100/{{ s.slug }}"
+          >
+            <div class="flex flex-wrap items-center justify-between gap-2">
+              <div>
+                <h2 class="text-lg font-medium text-slate-900">{{ s.topic }} · {{ s.personality }}</h2>
+                <p class="text-sm text-slate-500">/{{ s.slug }} — {{ s.items|length }} items — updated {{ s.updated_at }}</p>
+              </div>
+              <span class="rounded-full bg-slate-900 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-white">Open</span>
+            </div>
+          </a>
+        </li>
+      {% endfor %}
+    </ul>
+  {% endif %}
+</section>
+{% endblock %}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,3 +1,4 @@
 fastapi==0.109.2
 uvicorn[standard]==0.27.1
 python-multipart==0.0.9
+Jinja2==3.1.4


### PR DESCRIPTION
## Summary
- add a shared Tailwind layout with sticky header/footer and expose the Top100 link in the navigation
- restyle the Top100 list and editor pages to adopt the shared layout and lighter card styling
- flag Top100 template responses with an active nav key so the new header highlights the section

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68e6222d42588325b6fb7366049250e2