### PR TITLE
Add placeholders for AI engineering lessons 51-100

### DIFF
--- a/_original/100-ai-engineering.md
+++ b/_original/100-ai-engineering.md
@@ -1,0 +1,3 @@
+# Lesson 100 — Coming Soon
+
+Content for AI Engineer Roadmap Skill #100 is being prepared. Detailed objectives, key concepts, and project guidance will be published soon.

--- a/_original/51-ai-engineering.md
+++ b/_original/51-ai-engineering.md
@@ -1,0 +1,3 @@
+# Lesson 51 — Coming Soon
+
+Content for AI Engineer Roadmap Skill #51 is being prepared. Detailed objectives, key concepts, and project guidance will be published soon.

--- a/_original/52-ai-engineering.md
+++ b/_original/52-ai-engineering.md
@@ -1,0 +1,3 @@
+# Lesson 52 — Coming Soon
+
+Content for AI Engineer Roadmap Skill #52 is being prepared. Detailed objectives, key concepts, and project guidance will be published soon.

--- a/_original/53-ai-engineering.md
+++ b/_original/53-ai-engineering.md
@@ -1,0 +1,3 @@
+# Lesson 53 — Coming Soon
+
+Content for AI Engineer Roadmap Skill #53 is being prepared. Detailed objectives, key concepts, and project guidance will be published soon.

--- a/_original/54-ai-engineering.md
+++ b/_original/54-ai-engineering.md
@@ -1,0 +1,3 @@
+# Lesson 54 — Coming Soon
+
+Content for AI Engineer Roadmap Skill #54 is being prepared. Detailed objectives, key concepts, and project guidance will be published soon.

--- a/_original/55-ai-engineering.md
+++ b/_original/55-ai-engineering.md
@@ -1,0 +1,3 @@
+# Lesson 55 — Coming Soon
+
+Content for AI Engineer Roadmap Skill #55 is being prepared. Detailed objectives, key concepts, and project guidance will be published soon.

--- a/_original/56-ai-engineering.md
+++ b/_original/56-ai-engineering.md
@@ -1,0 +1,3 @@
+# Lesson 56 — Coming Soon
+
+Content for AI Engineer Roadmap Skill #56 is being prepared. Detailed objectives, key concepts, and project guidance will be published soon.

--- a/_original/57-ai-engineering.md
+++ b/_original/57-ai-engineering.md
@@ -1,0 +1,3 @@
+# Lesson 57 — Coming Soon
+
+Content for AI Engineer Roadmap Skill #57 is being prepared. Detailed objectives, key concepts, and project guidance will be published soon.

--- a/_original/58-ai-engineering.md
+++ b/_original/58-ai-engineering.md
@@ -1,0 +1,3 @@
+# Lesson 58 — Coming Soon
+
+Content for AI Engineer Roadmap Skill #58 is being prepared. Detailed objectives, key concepts, and project guidance will be published soon.

--- a/_original/59-ai-engineering.md
+++ b/_original/59-ai-engineering.md
@@ -1,0 +1,3 @@
+# Lesson 59 — Coming Soon
+
+Content for AI Engineer Roadmap Skill #59 is being prepared. Detailed objectives, key concepts, and project guidance will be published soon.

--- a/_original/60-ai-engineering.md
+++ b/_original/60-ai-engineering.md
@@ -1,0 +1,3 @@
+# Lesson 60 — Coming Soon
+
+Content for AI Engineer Roadmap Skill #60 is being prepared. Detailed objectives, key concepts, and project guidance will be published soon.

--- a/_original/61-ai-engineering.md
+++ b/_original/61-ai-engineering.md
@@ -1,0 +1,3 @@
+# Lesson 61 — Coming Soon
+
+Content for AI Engineer Roadmap Skill #61 is being prepared. Detailed objectives, key concepts, and project guidance will be published soon.

--- a/_original/62-ai-engineering.md
+++ b/_original/62-ai-engineering.md
@@ -1,0 +1,3 @@
+# Lesson 62 — Coming Soon
+
+Content for AI Engineer Roadmap Skill #62 is being prepared. Detailed objectives, key concepts, and project guidance will be published soon.

--- a/_original/63-ai-engineering.md
+++ b/_original/63-ai-engineering.md
@@ -1,0 +1,3 @@
+# Lesson 63 — Coming Soon
+
+Content for AI Engineer Roadmap Skill #63 is being prepared. Detailed objectives, key concepts, and project guidance will be published soon.

--- a/_original/64-ai-engineering.md
+++ b/_original/64-ai-engineering.md
@@ -1,0 +1,3 @@
+# Lesson 64 — Coming Soon
+
+Content for AI Engineer Roadmap Skill #64 is being prepared. Detailed objectives, key concepts, and project guidance will be published soon.

--- a/_original/65-ai-engineering.md
+++ b/_original/65-ai-engineering.md
@@ -1,0 +1,3 @@
+# Lesson 65 — Coming Soon
+
+Content for AI Engineer Roadmap Skill #65 is being prepared. Detailed objectives, key concepts, and project guidance will be published soon.

--- a/_original/66-ai-engineering.md
+++ b/_original/66-ai-engineering.md
@@ -1,0 +1,3 @@
+# Lesson 66 — Coming Soon
+
+Content for AI Engineer Roadmap Skill #66 is being prepared. Detailed objectives, key concepts, and project guidance will be published soon.

--- a/_original/67-ai-engineering.md
+++ b/_original/67-ai-engineering.md
@@ -1,0 +1,3 @@
+# Lesson 67 — Coming Soon
+
+Content for AI Engineer Roadmap Skill #67 is being prepared. Detailed objectives, key concepts, and project guidance will be published soon.

--- a/_original/68-ai-engineering.md
+++ b/_original/68-ai-engineering.md
@@ -1,0 +1,3 @@
+# Lesson 68 — Coming Soon
+
+Content for AI Engineer Roadmap Skill #68 is being prepared. Detailed objectives, key concepts, and project guidance will be published soon.

--- a/_original/69-ai-engineering.md
+++ b/_original/69-ai-engineering.md
@@ -1,0 +1,3 @@
+# Lesson 69 — Coming Soon
+
+Content for AI Engineer Roadmap Skill #69 is being prepared. Detailed objectives, key concepts, and project guidance will be published soon.

--- a/_original/70-ai-engineering.md
+++ b/_original/70-ai-engineering.md
@@ -1,0 +1,3 @@
+# Lesson 70 — Coming Soon
+
+Content for AI Engineer Roadmap Skill #70 is being prepared. Detailed objectives, key concepts, and project guidance will be published soon.

--- a/_original/71-ai-engineering.md
+++ b/_original/71-ai-engineering.md
@@ -1,0 +1,3 @@
+# Lesson 71 — Coming Soon
+
+Content for AI Engineer Roadmap Skill #71 is being prepared. Detailed objectives, key concepts, and project guidance will be published soon.

--- a/_original/72-ai-engineering.md
+++ b/_original/72-ai-engineering.md
@@ -1,0 +1,3 @@
+# Lesson 72 — Coming Soon
+
+Content for AI Engineer Roadmap Skill #72 is being prepared. Detailed objectives, key concepts, and project guidance will be published soon.

--- a/_original/73-ai-engineering.md
+++ b/_original/73-ai-engineering.md
@@ -1,0 +1,3 @@
+# Lesson 73 — Coming Soon
+
+Content for AI Engineer Roadmap Skill #73 is being prepared. Detailed objectives, key concepts, and project guidance will be published soon.

--- a/_original/74-ai-engineering.md
+++ b/_original/74-ai-engineering.md
@@ -1,0 +1,3 @@
+# Lesson 74 — Coming Soon
+
+Content for AI Engineer Roadmap Skill #74 is being prepared. Detailed objectives, key concepts, and project guidance will be published soon.

--- a/_original/75-ai-engineering.md
+++ b/_original/75-ai-engineering.md
@@ -1,0 +1,3 @@
+# Lesson 75 — Coming Soon
+
+Content for AI Engineer Roadmap Skill #75 is being prepared. Detailed objectives, key concepts, and project guidance will be published soon.

--- a/_original/76-ai-engineering.md
+++ b/_original/76-ai-engineering.md
@@ -1,0 +1,3 @@
+# Lesson 76 — Coming Soon
+
+Content for AI Engineer Roadmap Skill #76 is being prepared. Detailed objectives, key concepts, and project guidance will be published soon.

--- a/_original/77-ai-engineering.md
+++ b/_original/77-ai-engineering.md
@@ -1,0 +1,3 @@
+# Lesson 77 — Coming Soon
+
+Content for AI Engineer Roadmap Skill #77 is being prepared. Detailed objectives, key concepts, and project guidance will be published soon.

--- a/_original/78-ai-engineering.md
+++ b/_original/78-ai-engineering.md
@@ -1,0 +1,3 @@
+# Lesson 78 — Coming Soon
+
+Content for AI Engineer Roadmap Skill #78 is being prepared. Detailed objectives, key concepts, and project guidance will be published soon.

--- a/_original/79-ai-engineering.md
+++ b/_original/79-ai-engineering.md
@@ -1,0 +1,3 @@
+# Lesson 79 — Coming Soon
+
+Content for AI Engineer Roadmap Skill #79 is being prepared. Detailed objectives, key concepts, and project guidance will be published soon.

--- a/_original/80-ai-engineering.md
+++ b/_original/80-ai-engineering.md
@@ -1,0 +1,3 @@
+# Lesson 80 — Coming Soon
+
+Content for AI Engineer Roadmap Skill #80 is being prepared. Detailed objectives, key concepts, and project guidance will be published soon.

--- a/_original/81-ai-engineering.md
+++ b/_original/81-ai-engineering.md
@@ -1,0 +1,3 @@
+# Lesson 81 — Coming Soon
+
+Content for AI Engineer Roadmap Skill #81 is being prepared. Detailed objectives, key concepts, and project guidance will be published soon.

--- a/_original/82-ai-engineering.md
+++ b/_original/82-ai-engineering.md
@@ -1,0 +1,3 @@
+# Lesson 82 — Coming Soon
+
+Content for AI Engineer Roadmap Skill #82 is being prepared. Detailed objectives, key concepts, and project guidance will be published soon.

--- a/_original/83-ai-engineering.md
+++ b/_original/83-ai-engineering.md
@@ -1,0 +1,3 @@
+# Lesson 83 — Coming Soon
+
+Content for AI Engineer Roadmap Skill #83 is being prepared. Detailed objectives, key concepts, and project guidance will be published soon.

--- a/_original/84-ai-engineering.md
+++ b/_original/84-ai-engineering.md
@@ -1,0 +1,3 @@
+# Lesson 84 — Coming Soon
+
+Content for AI Engineer Roadmap Skill #84 is being prepared. Detailed objectives, key concepts, and project guidance will be published soon.

--- a/_original/85-ai-engineering.md
+++ b/_original/85-ai-engineering.md
@@ -1,0 +1,3 @@
+# Lesson 85 — Coming Soon
+
+Content for AI Engineer Roadmap Skill #85 is being prepared. Detailed objectives, key concepts, and project guidance will be published soon.

--- a/_original/86-ai-engineering.md
+++ b/_original/86-ai-engineering.md
@@ -1,0 +1,3 @@
+# Lesson 86 — Coming Soon
+
+Content for AI Engineer Roadmap Skill #86 is being prepared. Detailed objectives, key concepts, and project guidance will be published soon.

--- a/_original/87-ai-engineering.md
+++ b/_original/87-ai-engineering.md
@@ -1,0 +1,3 @@
+# Lesson 87 — Coming Soon
+
+Content for AI Engineer Roadmap Skill #87 is being prepared. Detailed objectives, key concepts, and project guidance will be published soon.

--- a/_original/88-ai-engineering.md
+++ b/_original/88-ai-engineering.md
@@ -1,0 +1,3 @@
+# Lesson 88 — Coming Soon
+
+Content for AI Engineer Roadmap Skill #88 is being prepared. Detailed objectives, key concepts, and project guidance will be published soon.

--- a/_original/89-ai-engineering.md
+++ b/_original/89-ai-engineering.md
@@ -1,0 +1,3 @@
+# Lesson 89 — Coming Soon
+
+Content for AI Engineer Roadmap Skill #89 is being prepared. Detailed objectives, key concepts, and project guidance will be published soon.

--- a/_original/90-ai-engineering.md
+++ b/_original/90-ai-engineering.md
@@ -1,0 +1,3 @@
+# Lesson 90 — Coming Soon
+
+Content for AI Engineer Roadmap Skill #90 is being prepared. Detailed objectives, key concepts, and project guidance will be published soon.

--- a/_original/91-ai-engineering.md
+++ b/_original/91-ai-engineering.md
@@ -1,0 +1,3 @@
+# Lesson 91 — Coming Soon
+
+Content for AI Engineer Roadmap Skill #91 is being prepared. Detailed objectives, key concepts, and project guidance will be published soon.

--- a/_original/92-ai-engineering.md
+++ b/_original/92-ai-engineering.md
@@ -1,0 +1,3 @@
+# Lesson 92 — Coming Soon
+
+Content for AI Engineer Roadmap Skill #92 is being prepared. Detailed objectives, key concepts, and project guidance will be published soon.

--- a/_original/93-ai-engineering.md
+++ b/_original/93-ai-engineering.md
@@ -1,0 +1,3 @@
+# Lesson 93 — Coming Soon
+
+Content for AI Engineer Roadmap Skill #93 is being prepared. Detailed objectives, key concepts, and project guidance will be published soon.

--- a/_original/94-ai-engineering.md
+++ b/_original/94-ai-engineering.md
@@ -1,0 +1,3 @@
+# Lesson 94 — Coming Soon
+
+Content for AI Engineer Roadmap Skill #94 is being prepared. Detailed objectives, key concepts, and project guidance will be published soon.

--- a/_original/95-ai-engineering.md
+++ b/_original/95-ai-engineering.md
@@ -1,0 +1,3 @@
+# Lesson 95 — Coming Soon
+
+Content for AI Engineer Roadmap Skill #95 is being prepared. Detailed objectives, key concepts, and project guidance will be published soon.

--- a/_original/96-ai-engineering.md
+++ b/_original/96-ai-engineering.md
@@ -1,0 +1,3 @@
+# Lesson 96 — Coming Soon
+
+Content for AI Engineer Roadmap Skill #96 is being prepared. Detailed objectives, key concepts, and project guidance will be published soon.

--- a/_original/97-ai-engineering.md
+++ b/_original/97-ai-engineering.md
@@ -1,0 +1,3 @@
+# Lesson 97 — Coming Soon
+
+Content for AI Engineer Roadmap Skill #97 is being prepared. Detailed objectives, key concepts, and project guidance will be published soon.

--- a/_original/98-ai-engineering.md
+++ b/_original/98-ai-engineering.md
@@ -1,0 +1,3 @@
+# Lesson 98 — Coming Soon
+
+Content for AI Engineer Roadmap Skill #98 is being prepared. Detailed objectives, key concepts, and project guidance will be published soon.

--- a/_original/99-ai-engineering.md
+++ b/_original/99-ai-engineering.md
@@ -1,0 +1,3 @@
+# Lesson 99 — Coming Soon
+
+Content for AI Engineer Roadmap Skill #99 is being prepared. Detailed objectives, key concepts, and project guidance will be published soon.

--- a/ai-engineering/100-ai-engineering.md
+++ b/ai-engineering/100-ai-engineering.md
@@ -1,0 +1,15 @@
+# 🚧 Lesson 100 — Coming Soon
+
+### *AI Engineer Roadmap 2025 — Skill #100*
+
+---
+
+## 🚧 Placeholder
+The full lesson for **Skill #100** is currently being drafted. Future updates will expand this section with learning objectives, definitions, frameworks, and practical build exercises for AI engineers.
+
+---
+
+## 📌 Stay Tuned
+* Revisit earlier lessons to deepen your AI engineering fundamentals.
+* Prototype small projects with the tools and stacks already covered.
+* Check back soon for the complete Skill #100 lesson release.

--- a/ai-engineering/51-ai-engineering.md
+++ b/ai-engineering/51-ai-engineering.md
@@ -1,0 +1,15 @@
+# 🚧 Lesson 51 — Coming Soon
+
+### *AI Engineer Roadmap 2025 — Skill #51*
+
+---
+
+## 🚧 Placeholder
+The full lesson for **Skill #51** is currently being drafted. Future updates will expand this section with learning objectives, definitions, frameworks, and practical build exercises for AI engineers.
+
+---
+
+## 📌 Stay Tuned
+* Revisit earlier lessons to deepen your AI engineering fundamentals.
+* Prototype small projects with the tools and stacks already covered.
+* Check back soon for the complete Skill #51 lesson release.

--- a/ai-engineering/52-ai-engineering.md
+++ b/ai-engineering/52-ai-engineering.md
@@ -1,0 +1,15 @@
+# 🚧 Lesson 52 — Coming Soon
+
+### *AI Engineer Roadmap 2025 — Skill #52*
+
+---
+
+## 🚧 Placeholder
+The full lesson for **Skill #52** is currently being drafted. Future updates will expand this section with learning objectives, definitions, frameworks, and practical build exercises for AI engineers.
+
+---
+
+## 📌 Stay Tuned
+* Revisit earlier lessons to deepen your AI engineering fundamentals.
+* Prototype small projects with the tools and stacks already covered.
+* Check back soon for the complete Skill #52 lesson release.

--- a/ai-engineering/53-ai-engineering.md
+++ b/ai-engineering/53-ai-engineering.md
@@ -1,0 +1,15 @@
+# 🚧 Lesson 53 — Coming Soon
+
+### *AI Engineer Roadmap 2025 — Skill #53*
+
+---
+
+## 🚧 Placeholder
+The full lesson for **Skill #53** is currently being drafted. Future updates will expand this section with learning objectives, definitions, frameworks, and practical build exercises for AI engineers.
+
+---
+
+## 📌 Stay Tuned
+* Revisit earlier lessons to deepen your AI engineering fundamentals.
+* Prototype small projects with the tools and stacks already covered.
+* Check back soon for the complete Skill #53 lesson release.

--- a/ai-engineering/54-ai-engineering.md
+++ b/ai-engineering/54-ai-engineering.md
@@ -1,0 +1,15 @@
+# 🚧 Lesson 54 — Coming Soon
+
+### *AI Engineer Roadmap 2025 — Skill #54*
+
+---
+
+## 🚧 Placeholder
+The full lesson for **Skill #54** is currently being drafted. Future updates will expand this section with learning objectives, definitions, frameworks, and practical build exercises for AI engineers.
+
+---
+
+## 📌 Stay Tuned
+* Revisit earlier lessons to deepen your AI engineering fundamentals.
+* Prototype small projects with the tools and stacks already covered.
+* Check back soon for the complete Skill #54 lesson release.

--- a/ai-engineering/55-ai-engineering.md
+++ b/ai-engineering/55-ai-engineering.md
@@ -1,0 +1,15 @@
+# 🚧 Lesson 55 — Coming Soon
+
+### *AI Engineer Roadmap 2025 — Skill #55*
+
+---
+
+## 🚧 Placeholder
+The full lesson for **Skill #55** is currently being drafted. Future updates will expand this section with learning objectives, definitions, frameworks, and practical build exercises for AI engineers.
+
+---
+
+## 📌 Stay Tuned
+* Revisit earlier lessons to deepen your AI engineering fundamentals.
+* Prototype small projects with the tools and stacks already covered.
+* Check back soon for the complete Skill #55 lesson release.

--- a/ai-engineering/56-ai-engineering.md
+++ b/ai-engineering/56-ai-engineering.md
@@ -1,0 +1,15 @@
+# 🚧 Lesson 56 — Coming Soon
+
+### *AI Engineer Roadmap 2025 — Skill #56*
+
+---
+
+## 🚧 Placeholder
+The full lesson for **Skill #56** is currently being drafted. Future updates will expand this section with learning objectives, definitions, frameworks, and practical build exercises for AI engineers.
+
+---
+
+## 📌 Stay Tuned
+* Revisit earlier lessons to deepen your AI engineering fundamentals.
+* Prototype small projects with the tools and stacks already covered.
+* Check back soon for the complete Skill #56 lesson release.

--- a/ai-engineering/57-ai-engineering.md
+++ b/ai-engineering/57-ai-engineering.md
@@ -1,0 +1,15 @@
+# 🚧 Lesson 57 — Coming Soon
+
+### *AI Engineer Roadmap 2025 — Skill #57*
+
+---
+
+## 🚧 Placeholder
+The full lesson for **Skill #57** is currently being drafted. Future updates will expand this section with learning objectives, definitions, frameworks, and practical build exercises for AI engineers.
+
+---
+
+## 📌 Stay Tuned
+* Revisit earlier lessons to deepen your AI engineering fundamentals.
+* Prototype small projects with the tools and stacks already covered.
+* Check back soon for the complete Skill #57 lesson release.

--- a/ai-engineering/58-ai-engineering.md
+++ b/ai-engineering/58-ai-engineering.md
@@ -1,0 +1,15 @@
+# 🚧 Lesson 58 — Coming Soon
+
+### *AI Engineer Roadmap 2025 — Skill #58*
+
+---
+
+## 🚧 Placeholder
+The full lesson for **Skill #58** is currently being drafted. Future updates will expand this section with learning objectives, definitions, frameworks, and practical build exercises for AI engineers.
+
+---
+
+## 📌 Stay Tuned
+* Revisit earlier lessons to deepen your AI engineering fundamentals.
+* Prototype small projects with the tools and stacks already covered.
+* Check back soon for the complete Skill #58 lesson release.

--- a/ai-engineering/59-ai-engineering.md
+++ b/ai-engineering/59-ai-engineering.md
@@ -1,0 +1,15 @@
+# 🚧 Lesson 59 — Coming Soon
+
+### *AI Engineer Roadmap 2025 — Skill #59*
+
+---
+
+## 🚧 Placeholder
+The full lesson for **Skill #59** is currently being drafted. Future updates will expand this section with learning objectives, definitions, frameworks, and practical build exercises for AI engineers.
+
+---
+
+## 📌 Stay Tuned
+* Revisit earlier lessons to deepen your AI engineering fundamentals.
+* Prototype small projects with the tools and stacks already covered.
+* Check back soon for the complete Skill #59 lesson release.

--- a/ai-engineering/60-ai-engineering.md
+++ b/ai-engineering/60-ai-engineering.md
@@ -1,0 +1,15 @@
+# 🚧 Lesson 60 — Coming Soon
+
+### *AI Engineer Roadmap 2025 — Skill #60*
+
+---
+
+## 🚧 Placeholder
+The full lesson for **Skill #60** is currently being drafted. Future updates will expand this section with learning objectives, definitions, frameworks, and practical build exercises for AI engineers.
+
+---
+
+## 📌 Stay Tuned
+* Revisit earlier lessons to deepen your AI engineering fundamentals.
+* Prototype small projects with the tools and stacks already covered.
+* Check back soon for the complete Skill #60 lesson release.

--- a/ai-engineering/61-ai-engineering.md
+++ b/ai-engineering/61-ai-engineering.md
@@ -1,0 +1,15 @@
+# 🚧 Lesson 61 — Coming Soon
+
+### *AI Engineer Roadmap 2025 — Skill #61*
+
+---
+
+## 🚧 Placeholder
+The full lesson for **Skill #61** is currently being drafted. Future updates will expand this section with learning objectives, definitions, frameworks, and practical build exercises for AI engineers.
+
+---
+
+## 📌 Stay Tuned
+* Revisit earlier lessons to deepen your AI engineering fundamentals.
+* Prototype small projects with the tools and stacks already covered.
+* Check back soon for the complete Skill #61 lesson release.

--- a/ai-engineering/62-ai-engineering.md
+++ b/ai-engineering/62-ai-engineering.md
@@ -1,0 +1,15 @@
+# 🚧 Lesson 62 — Coming Soon
+
+### *AI Engineer Roadmap 2025 — Skill #62*
+
+---
+
+## 🚧 Placeholder
+The full lesson for **Skill #62** is currently being drafted. Future updates will expand this section with learning objectives, definitions, frameworks, and practical build exercises for AI engineers.
+
+---
+
+## 📌 Stay Tuned
+* Revisit earlier lessons to deepen your AI engineering fundamentals.
+* Prototype small projects with the tools and stacks already covered.
+* Check back soon for the complete Skill #62 lesson release.

--- a/ai-engineering/63-ai-engineering.md
+++ b/ai-engineering/63-ai-engineering.md
@@ -1,0 +1,15 @@
+# 🚧 Lesson 63 — Coming Soon
+
+### *AI Engineer Roadmap 2025 — Skill #63*
+
+---
+
+## 🚧 Placeholder
+The full lesson for **Skill #63** is currently being drafted. Future updates will expand this section with learning objectives, definitions, frameworks, and practical build exercises for AI engineers.
+
+---
+
+## 📌 Stay Tuned
+* Revisit earlier lessons to deepen your AI engineering fundamentals.
+* Prototype small projects with the tools and stacks already covered.
+* Check back soon for the complete Skill #63 lesson release.

--- a/ai-engineering/64-ai-engineering.md
+++ b/ai-engineering/64-ai-engineering.md
@@ -1,0 +1,15 @@
+# 🚧 Lesson 64 — Coming Soon
+
+### *AI Engineer Roadmap 2025 — Skill #64*
+
+---
+
+## 🚧 Placeholder
+The full lesson for **Skill #64** is currently being drafted. Future updates will expand this section with learning objectives, definitions, frameworks, and practical build exercises for AI engineers.
+
+---
+
+## 📌 Stay Tuned
+* Revisit earlier lessons to deepen your AI engineering fundamentals.
+* Prototype small projects with the tools and stacks already covered.
+* Check back soon for the complete Skill #64 lesson release.

--- a/ai-engineering/65-ai-engineering.md
+++ b/ai-engineering/65-ai-engineering.md
@@ -1,0 +1,15 @@
+# 🚧 Lesson 65 — Coming Soon
+
+### *AI Engineer Roadmap 2025 — Skill #65*
+
+---
+
+## 🚧 Placeholder
+The full lesson for **Skill #65** is currently being drafted. Future updates will expand this section with learning objectives, definitions, frameworks, and practical build exercises for AI engineers.
+
+---
+
+## 📌 Stay Tuned
+* Revisit earlier lessons to deepen your AI engineering fundamentals.
+* Prototype small projects with the tools and stacks already covered.
+* Check back soon for the complete Skill #65 lesson release.

--- a/ai-engineering/66-ai-engineering.md
+++ b/ai-engineering/66-ai-engineering.md
@@ -1,0 +1,15 @@
+# 🚧 Lesson 66 — Coming Soon
+
+### *AI Engineer Roadmap 2025 — Skill #66*
+
+---
+
+## 🚧 Placeholder
+The full lesson for **Skill #66** is currently being drafted. Future updates will expand this section with learning objectives, definitions, frameworks, and practical build exercises for AI engineers.
+
+---
+
+## 📌 Stay Tuned
+* Revisit earlier lessons to deepen your AI engineering fundamentals.
+* Prototype small projects with the tools and stacks already covered.
+* Check back soon for the complete Skill #66 lesson release.

--- a/ai-engineering/67-ai-engineering.md
+++ b/ai-engineering/67-ai-engineering.md
@@ -1,0 +1,15 @@
+# 🚧 Lesson 67 — Coming Soon
+
+### *AI Engineer Roadmap 2025 — Skill #67*
+
+---
+
+## 🚧 Placeholder
+The full lesson for **Skill #67** is currently being drafted. Future updates will expand this section with learning objectives, definitions, frameworks, and practical build exercises for AI engineers.
+
+---
+
+## 📌 Stay Tuned
+* Revisit earlier lessons to deepen your AI engineering fundamentals.
+* Prototype small projects with the tools and stacks already covered.
+* Check back soon for the complete Skill #67 lesson release.

--- a/ai-engineering/68-ai-engineering.md
+++ b/ai-engineering/68-ai-engineering.md
@@ -1,0 +1,15 @@
+# 🚧 Lesson 68 — Coming Soon
+
+### *AI Engineer Roadmap 2025 — Skill #68*
+
+---
+
+## 🚧 Placeholder
+The full lesson for **Skill #68** is currently being drafted. Future updates will expand this section with learning objectives, definitions, frameworks, and practical build exercises for AI engineers.
+
+---
+
+## 📌 Stay Tuned
+* Revisit earlier lessons to deepen your AI engineering fundamentals.
+* Prototype small projects with the tools and stacks already covered.
+* Check back soon for the complete Skill #68 lesson release.

--- a/ai-engineering/69-ai-engineering.md
+++ b/ai-engineering/69-ai-engineering.md
@@ -1,0 +1,15 @@
+# 🚧 Lesson 69 — Coming Soon
+
+### *AI Engineer Roadmap 2025 — Skill #69*
+
+---
+
+## 🚧 Placeholder
+The full lesson for **Skill #69** is currently being drafted. Future updates will expand this section with learning objectives, definitions, frameworks, and practical build exercises for AI engineers.
+
+---
+
+## 📌 Stay Tuned
+* Revisit earlier lessons to deepen your AI engineering fundamentals.
+* Prototype small projects with the tools and stacks already covered.
+* Check back soon for the complete Skill #69 lesson release.

--- a/ai-engineering/70-ai-engineering.md
+++ b/ai-engineering/70-ai-engineering.md
@@ -1,0 +1,15 @@
+# 🚧 Lesson 70 — Coming Soon
+
+### *AI Engineer Roadmap 2025 — Skill #70*
+
+---
+
+## 🚧 Placeholder
+The full lesson for **Skill #70** is currently being drafted. Future updates will expand this section with learning objectives, definitions, frameworks, and practical build exercises for AI engineers.
+
+---
+
+## 📌 Stay Tuned
+* Revisit earlier lessons to deepen your AI engineering fundamentals.
+* Prototype small projects with the tools and stacks already covered.
+* Check back soon for the complete Skill #70 lesson release.

--- a/ai-engineering/71-ai-engineering.md
+++ b/ai-engineering/71-ai-engineering.md
@@ -1,0 +1,15 @@
+# 🚧 Lesson 71 — Coming Soon
+
+### *AI Engineer Roadmap 2025 — Skill #71*
+
+---
+
+## 🚧 Placeholder
+The full lesson for **Skill #71** is currently being drafted. Future updates will expand this section with learning objectives, definitions, frameworks, and practical build exercises for AI engineers.
+
+---
+
+## 📌 Stay Tuned
+* Revisit earlier lessons to deepen your AI engineering fundamentals.
+* Prototype small projects with the tools and stacks already covered.
+* Check back soon for the complete Skill #71 lesson release.

--- a/ai-engineering/72-ai-engineering.md
+++ b/ai-engineering/72-ai-engineering.md
@@ -1,0 +1,15 @@
+# 🚧 Lesson 72 — Coming Soon
+
+### *AI Engineer Roadmap 2025 — Skill #72*
+
+---
+
+## 🚧 Placeholder
+The full lesson for **Skill #72** is currently being drafted. Future updates will expand this section with learning objectives, definitions, frameworks, and practical build exercises for AI engineers.
+
+---
+
+## 📌 Stay Tuned
+* Revisit earlier lessons to deepen your AI engineering fundamentals.
+* Prototype small projects with the tools and stacks already covered.
+* Check back soon for the complete Skill #72 lesson release.

--- a/ai-engineering/73-ai-engineering.md
+++ b/ai-engineering/73-ai-engineering.md
@@ -1,0 +1,15 @@
+# 🚧 Lesson 73 — Coming Soon
+
+### *AI Engineer Roadmap 2025 — Skill #73*
+
+---
+
+## 🚧 Placeholder
+The full lesson for **Skill #73** is currently being drafted. Future updates will expand this section with learning objectives, definitions, frameworks, and practical build exercises for AI engineers.
+
+---
+
+## 📌 Stay Tuned
+* Revisit earlier lessons to deepen your AI engineering fundamentals.
+* Prototype small projects with the tools and stacks already covered.
+* Check back soon for the complete Skill #73 lesson release.

--- a/ai-engineering/74-ai-engineering.md
+++ b/ai-engineering/74-ai-engineering.md
@@ -1,0 +1,15 @@
+# 🚧 Lesson 74 — Coming Soon
+
+### *AI Engineer Roadmap 2025 — Skill #74*
+
+---
+
+## 🚧 Placeholder
+The full lesson for **Skill #74** is currently being drafted. Future updates will expand this section with learning objectives, definitions, frameworks, and practical build exercises for AI engineers.
+
+---
+
+## 📌 Stay Tuned
+* Revisit earlier lessons to deepen your AI engineering fundamentals.
+* Prototype small projects with the tools and stacks already covered.
+* Check back soon for the complete Skill #74 lesson release.

--- a/ai-engineering/75-ai-engineering.md
+++ b/ai-engineering/75-ai-engineering.md
@@ -1,0 +1,15 @@
+# 🚧 Lesson 75 — Coming Soon
+
+### *AI Engineer Roadmap 2025 — Skill #75*
+
+---
+
+## 🚧 Placeholder
+The full lesson for **Skill #75** is currently being drafted. Future updates will expand this section with learning objectives, definitions, frameworks, and practical build exercises for AI engineers.
+
+---
+
+## 📌 Stay Tuned
+* Revisit earlier lessons to deepen your AI engineering fundamentals.
+* Prototype small projects with the tools and stacks already covered.
+* Check back soon for the complete Skill #75 lesson release.

--- a/ai-engineering/76-ai-engineering.md
+++ b/ai-engineering/76-ai-engineering.md
@@ -1,0 +1,15 @@
+# 🚧 Lesson 76 — Coming Soon
+
+### *AI Engineer Roadmap 2025 — Skill #76*
+
+---
+
+## 🚧 Placeholder
+The full lesson for **Skill #76** is currently being drafted. Future updates will expand this section with learning objectives, definitions, frameworks, and practical build exercises for AI engineers.
+
+---
+
+## 📌 Stay Tuned
+* Revisit earlier lessons to deepen your AI engineering fundamentals.
+* Prototype small projects with the tools and stacks already covered.
+* Check back soon for the complete Skill #76 lesson release.

--- a/ai-engineering/77-ai-engineering.md
+++ b/ai-engineering/77-ai-engineering.md
@@ -1,0 +1,15 @@
+# 🚧 Lesson 77 — Coming Soon
+
+### *AI Engineer Roadmap 2025 — Skill #77*
+
+---
+
+## 🚧 Placeholder
+The full lesson for **Skill #77** is currently being drafted. Future updates will expand this section with learning objectives, definitions, frameworks, and practical build exercises for AI engineers.
+
+---
+
+## 📌 Stay Tuned
+* Revisit earlier lessons to deepen your AI engineering fundamentals.
+* Prototype small projects with the tools and stacks already covered.
+* Check back soon for the complete Skill #77 lesson release.

--- a/ai-engineering/78-ai-engineering.md
+++ b/ai-engineering/78-ai-engineering.md
@@ -1,0 +1,15 @@
+# 🚧 Lesson 78 — Coming Soon
+
+### *AI Engineer Roadmap 2025 — Skill #78*
+
+---
+
+## 🚧 Placeholder
+The full lesson for **Skill #78** is currently being drafted. Future updates will expand this section with learning objectives, definitions, frameworks, and practical build exercises for AI engineers.
+
+---
+
+## 📌 Stay Tuned
+* Revisit earlier lessons to deepen your AI engineering fundamentals.
+* Prototype small projects with the tools and stacks already covered.
+* Check back soon for the complete Skill #78 lesson release.

--- a/ai-engineering/79-ai-engineering.md
+++ b/ai-engineering/79-ai-engineering.md
@@ -1,0 +1,15 @@
+# 🚧 Lesson 79 — Coming Soon
+
+### *AI Engineer Roadmap 2025 — Skill #79*
+
+---
+
+## 🚧 Placeholder
+The full lesson for **Skill #79** is currently being drafted. Future updates will expand this section with learning objectives, definitions, frameworks, and practical build exercises for AI engineers.
+
+---
+
+## 📌 Stay Tuned
+* Revisit earlier lessons to deepen your AI engineering fundamentals.
+* Prototype small projects with the tools and stacks already covered.
+* Check back soon for the complete Skill #79 lesson release.

--- a/ai-engineering/80-ai-engineering.md
+++ b/ai-engineering/80-ai-engineering.md
@@ -1,0 +1,15 @@
+# 🚧 Lesson 80 — Coming Soon
+
+### *AI Engineer Roadmap 2025 — Skill #80*
+
+---
+
+## 🚧 Placeholder
+The full lesson for **Skill #80** is currently being drafted. Future updates will expand this section with learning objectives, definitions, frameworks, and practical build exercises for AI engineers.
+
+---
+
+## 📌 Stay Tuned
+* Revisit earlier lessons to deepen your AI engineering fundamentals.
+* Prototype small projects with the tools and stacks already covered.
+* Check back soon for the complete Skill #80 lesson release.

--- a/ai-engineering/81-ai-engineering.md
+++ b/ai-engineering/81-ai-engineering.md
@@ -1,0 +1,15 @@
+# 🚧 Lesson 81 — Coming Soon
+
+### *AI Engineer Roadmap 2025 — Skill #81*
+
+---
+
+## 🚧 Placeholder
+The full lesson for **Skill #81** is currently being drafted. Future updates will expand this section with learning objectives, definitions, frameworks, and practical build exercises for AI engineers.
+
+---
+
+## 📌 Stay Tuned
+* Revisit earlier lessons to deepen your AI engineering fundamentals.
+* Prototype small projects with the tools and stacks already covered.
+* Check back soon for the complete Skill #81 lesson release.

--- a/ai-engineering/82-ai-engineering.md
+++ b/ai-engineering/82-ai-engineering.md
@@ -1,0 +1,15 @@
+# 🚧 Lesson 82 — Coming Soon
+
+### *AI Engineer Roadmap 2025 — Skill #82*
+
+---
+
+## 🚧 Placeholder
+The full lesson for **Skill #82** is currently being drafted. Future updates will expand this section with learning objectives, definitions, frameworks, and practical build exercises for AI engineers.
+
+---
+
+## 📌 Stay Tuned
+* Revisit earlier lessons to deepen your AI engineering fundamentals.
+* Prototype small projects with the tools and stacks already covered.
+* Check back soon for the complete Skill #82 lesson release.

--- a/ai-engineering/83-ai-engineering.md
+++ b/ai-engineering/83-ai-engineering.md
@@ -1,0 +1,15 @@
+# 🚧 Lesson 83 — Coming Soon
+
+### *AI Engineer Roadmap 2025 — Skill #83*
+
+---
+
+## 🚧 Placeholder
+The full lesson for **Skill #83** is currently being drafted. Future updates will expand this section with learning objectives, definitions, frameworks, and practical build exercises for AI engineers.
+
+---
+
+## 📌 Stay Tuned
+* Revisit earlier lessons to deepen your AI engineering fundamentals.
+* Prototype small projects with the tools and stacks already covered.
+* Check back soon for the complete Skill #83 lesson release.

--- a/ai-engineering/84-ai-engineering.md
+++ b/ai-engineering/84-ai-engineering.md
@@ -1,0 +1,15 @@
+# 🚧 Lesson 84 — Coming Soon
+
+### *AI Engineer Roadmap 2025 — Skill #84*
+
+---
+
+## 🚧 Placeholder
+The full lesson for **Skill #84** is currently being drafted. Future updates will expand this section with learning objectives, definitions, frameworks, and practical build exercises for AI engineers.
+
+---
+
+## 📌 Stay Tuned
+* Revisit earlier lessons to deepen your AI engineering fundamentals.
+* Prototype small projects with the tools and stacks already covered.
+* Check back soon for the complete Skill #84 lesson release.

--- a/ai-engineering/85-ai-engineering.md
+++ b/ai-engineering/85-ai-engineering.md
@@ -1,0 +1,15 @@
+# 🚧 Lesson 85 — Coming Soon
+
+### *AI Engineer Roadmap 2025 — Skill #85*
+
+---
+
+## 🚧 Placeholder
+The full lesson for **Skill #85** is currently being drafted. Future updates will expand this section with learning objectives, definitions, frameworks, and practical build exercises for AI engineers.
+
+---
+
+## 📌 Stay Tuned
+* Revisit earlier lessons to deepen your AI engineering fundamentals.
+* Prototype small projects with the tools and stacks already covered.
+* Check back soon for the complete Skill #85 lesson release.

--- a/ai-engineering/86-ai-engineering.md
+++ b/ai-engineering/86-ai-engineering.md
@@ -1,0 +1,15 @@
+# 🚧 Lesson 86 — Coming Soon
+
+### *AI Engineer Roadmap 2025 — Skill #86*
+
+---
+
+## 🚧 Placeholder
+The full lesson for **Skill #86** is currently being drafted. Future updates will expand this section with learning objectives, definitions, frameworks, and practical build exercises for AI engineers.
+
+---
+
+## 📌 Stay Tuned
+* Revisit earlier lessons to deepen your AI engineering fundamentals.
+* Prototype small projects with the tools and stacks already covered.
+* Check back soon for the complete Skill #86 lesson release.

--- a/ai-engineering/87-ai-engineering.md
+++ b/ai-engineering/87-ai-engineering.md
@@ -1,0 +1,15 @@
+# 🚧 Lesson 87 — Coming Soon
+
+### *AI Engineer Roadmap 2025 — Skill #87*
+
+---
+
+## 🚧 Placeholder
+The full lesson for **Skill #87** is currently being drafted. Future updates will expand this section with learning objectives, definitions, frameworks, and practical build exercises for AI engineers.
+
+---
+
+## 📌 Stay Tuned
+* Revisit earlier lessons to deepen your AI engineering fundamentals.
+* Prototype small projects with the tools and stacks already covered.
+* Check back soon for the complete Skill #87 lesson release.

--- a/ai-engineering/88-ai-engineering.md
+++ b/ai-engineering/88-ai-engineering.md
@@ -1,0 +1,15 @@
+# 🚧 Lesson 88 — Coming Soon
+
+### *AI Engineer Roadmap 2025 — Skill #88*
+
+---
+
+## 🚧 Placeholder
+The full lesson for **Skill #88** is currently being drafted. Future updates will expand this section with learning objectives, definitions, frameworks, and practical build exercises for AI engineers.
+
+---
+
+## 📌 Stay Tuned
+* Revisit earlier lessons to deepen your AI engineering fundamentals.
+* Prototype small projects with the tools and stacks already covered.
+* Check back soon for the complete Skill #88 lesson release.

--- a/ai-engineering/89-ai-engineering.md
+++ b/ai-engineering/89-ai-engineering.md
@@ -1,0 +1,15 @@
+# 🚧 Lesson 89 — Coming Soon
+
+### *AI Engineer Roadmap 2025 — Skill #89*
+
+---
+
+## 🚧 Placeholder
+The full lesson for **Skill #89** is currently being drafted. Future updates will expand this section with learning objectives, definitions, frameworks, and practical build exercises for AI engineers.
+
+---
+
+## 📌 Stay Tuned
+* Revisit earlier lessons to deepen your AI engineering fundamentals.
+* Prototype small projects with the tools and stacks already covered.
+* Check back soon for the complete Skill #89 lesson release.

--- a/ai-engineering/90-ai-engineering.md
+++ b/ai-engineering/90-ai-engineering.md
@@ -1,0 +1,15 @@
+# 🚧 Lesson 90 — Coming Soon
+
+### *AI Engineer Roadmap 2025 — Skill #90*
+
+---
+
+## 🚧 Placeholder
+The full lesson for **Skill #90** is currently being drafted. Future updates will expand this section with learning objectives, definitions, frameworks, and practical build exercises for AI engineers.
+
+---
+
+## 📌 Stay Tuned
+* Revisit earlier lessons to deepen your AI engineering fundamentals.
+* Prototype small projects with the tools and stacks already covered.
+* Check back soon for the complete Skill #90 lesson release.

--- a/ai-engineering/91-ai-engineering.md
+++ b/ai-engineering/91-ai-engineering.md
@@ -1,0 +1,15 @@
+# 🚧 Lesson 91 — Coming Soon
+
+### *AI Engineer Roadmap 2025 — Skill #91*
+
+---
+
+## 🚧 Placeholder
+The full lesson for **Skill #91** is currently being drafted. Future updates will expand this section with learning objectives, definitions, frameworks, and practical build exercises for AI engineers.
+
+---
+
+## 📌 Stay Tuned
+* Revisit earlier lessons to deepen your AI engineering fundamentals.
+* Prototype small projects with the tools and stacks already covered.
+* Check back soon for the complete Skill #91 lesson release.

--- a/ai-engineering/92-ai-engineering.md
+++ b/ai-engineering/92-ai-engineering.md
@@ -1,0 +1,15 @@
+# 🚧 Lesson 92 — Coming Soon
+
+### *AI Engineer Roadmap 2025 — Skill #92*
+
+---
+
+## 🚧 Placeholder
+The full lesson for **Skill #92** is currently being drafted. Future updates will expand this section with learning objectives, definitions, frameworks, and practical build exercises for AI engineers.
+
+---
+
+## 📌 Stay Tuned
+* Revisit earlier lessons to deepen your AI engineering fundamentals.
+* Prototype small projects with the tools and stacks already covered.
+* Check back soon for the complete Skill #92 lesson release.

--- a/ai-engineering/93-ai-engineering.md
+++ b/ai-engineering/93-ai-engineering.md
@@ -1,0 +1,15 @@
+# 🚧 Lesson 93 — Coming Soon
+
+### *AI Engineer Roadmap 2025 — Skill #93*
+
+---
+
+## 🚧 Placeholder
+The full lesson for **Skill #93** is currently being drafted. Future updates will expand this section with learning objectives, definitions, frameworks, and practical build exercises for AI engineers.
+
+---
+
+## 📌 Stay Tuned
+* Revisit earlier lessons to deepen your AI engineering fundamentals.
+* Prototype small projects with the tools and stacks already covered.
+* Check back soon for the complete Skill #93 lesson release.

--- a/ai-engineering/94-ai-engineering.md
+++ b/ai-engineering/94-ai-engineering.md
@@ -1,0 +1,15 @@
+# 🚧 Lesson 94 — Coming Soon
+
+### *AI Engineer Roadmap 2025 — Skill #94*
+
+---
+
+## 🚧 Placeholder
+The full lesson for **Skill #94** is currently being drafted. Future updates will expand this section with learning objectives, definitions, frameworks, and practical build exercises for AI engineers.
+
+---
+
+## 📌 Stay Tuned
+* Revisit earlier lessons to deepen your AI engineering fundamentals.
+* Prototype small projects with the tools and stacks already covered.
+* Check back soon for the complete Skill #94 lesson release.

--- a/ai-engineering/95-ai-engineering.md
+++ b/ai-engineering/95-ai-engineering.md
@@ -1,0 +1,15 @@
+# 🚧 Lesson 95 — Coming Soon
+
+### *AI Engineer Roadmap 2025 — Skill #95*
+
+---
+
+## 🚧 Placeholder
+The full lesson for **Skill #95** is currently being drafted. Future updates will expand this section with learning objectives, definitions, frameworks, and practical build exercises for AI engineers.
+
+---
+
+## 📌 Stay Tuned
+* Revisit earlier lessons to deepen your AI engineering fundamentals.
+* Prototype small projects with the tools and stacks already covered.
+* Check back soon for the complete Skill #95 lesson release.

--- a/ai-engineering/96-ai-engineering.md
+++ b/ai-engineering/96-ai-engineering.md
@@ -1,0 +1,15 @@
+# 🚧 Lesson 96 — Coming Soon
+
+### *AI Engineer Roadmap 2025 — Skill #96*
+
+---
+
+## 🚧 Placeholder
+The full lesson for **Skill #96** is currently being drafted. Future updates will expand this section with learning objectives, definitions, frameworks, and practical build exercises for AI engineers.
+
+---
+
+## 📌 Stay Tuned
+* Revisit earlier lessons to deepen your AI engineering fundamentals.
+* Prototype small projects with the tools and stacks already covered.
+* Check back soon for the complete Skill #96 lesson release.

--- a/ai-engineering/97-ai-engineering.md
+++ b/ai-engineering/97-ai-engineering.md
@@ -1,0 +1,15 @@
+# 🚧 Lesson 97 — Coming Soon
+
+### *AI Engineer Roadmap 2025 — Skill #97*
+
+---
+
+## 🚧 Placeholder
+The full lesson for **Skill #97** is currently being drafted. Future updates will expand this section with learning objectives, definitions, frameworks, and practical build exercises for AI engineers.
+
+---
+
+## 📌 Stay Tuned
+* Revisit earlier lessons to deepen your AI engineering fundamentals.
+* Prototype small projects with the tools and stacks already covered.
+* Check back soon for the complete Skill #97 lesson release.

--- a/ai-engineering/98-ai-engineering.md
+++ b/ai-engineering/98-ai-engineering.md
@@ -1,0 +1,15 @@
+# 🚧 Lesson 98 — Coming Soon
+
+### *AI Engineer Roadmap 2025 — Skill #98*
+
+---
+
+## 🚧 Placeholder
+The full lesson for **Skill #98** is currently being drafted. Future updates will expand this section with learning objectives, definitions, frameworks, and practical build exercises for AI engineers.
+
+---
+
+## 📌 Stay Tuned
+* Revisit earlier lessons to deepen your AI engineering fundamentals.
+* Prototype small projects with the tools and stacks already covered.
+* Check back soon for the complete Skill #98 lesson release.

--- a/ai-engineering/99-ai-engineering.md
+++ b/ai-engineering/99-ai-engineering.md
@@ -1,0 +1,15 @@
+# 🚧 Lesson 99 — Coming Soon
+
+### *AI Engineer Roadmap 2025 — Skill #99*
+
+---
+
+## 🚧 Placeholder
+The full lesson for **Skill #99** is currently being drafted. Future updates will expand this section with learning objectives, definitions, frameworks, and practical build exercises for AI engineers.
+
+---
+
+## 📌 Stay Tuned
+* Revisit earlier lessons to deepen your AI engineering fundamentals.
+* Prototype small projects with the tools and stacks already covered.
+* Check back soon for the complete Skill #99 lesson release.


### PR DESCRIPTION
## Summary
- add placeholder lesson entries for AI Engineer Roadmap skills 51-100 in the `ai-engineering` set
- add matching placeholder source files in `_original`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f77e4091388325903f6dec80af3149